### PR TITLE
Refactor carousel state machine: distinguish scrolling from item transforms

### DIFF
--- a/design/00_architecture.md
+++ b/design/00_architecture.md
@@ -154,7 +154,15 @@ declare function createCarouselReduce(config: CarouselConfig): Reducer<CarouselP
 declare function toCarouselPublicState(state: CarouselPrivateState): CarouselPublicState;
 ```
 
-The carousel reducer uses a single global phase (`tracking | inertia | snapping | settled`) shared across the carousel strip and all items. This avoids an exponential explosion of per-item phase combinations. Motion events carrying an `itemId` are applied to that item's transform; any horizontal pan that exceeds the item's pan bounds (derived from its current scale) overflows to the carousel strip. On release, the carousel snaps to the nearest item boundary and each item snaps back to its neutral position (`x=0, y=0, scale=1`).
+The carousel reducer uses a single global phase shared across the carousel strip and all items. This avoids an exponential explosion of per-item phase combinations. The five phases are:
+
+- **scrolling** — the carousel strip is being scrolled; items are not transformed.
+- **focused** — one specific item (`focusedItemId`) is receiving gesture input. The carousel does not move and overflow beyond the item's pan bounds is discarded.
+- **inertia** — the focused item is coasting after the gesture was released; only that item advances; the carousel stays put.
+- **snapping** — the carousel strip is spring-snapping to the nearest item boundary; items remain at their current positions.
+- **settled** — everything is at rest.
+
+A motion event transitions to `focused` when it targets an item that is already zoomed in (`scale > 1`) or carries a scale change (`dScale ≠ 1`). All other motion transitions to `scrolling`. Items retain their position and scale after settling — they do not snap back to neutral.
 
 Implementation details:
 

--- a/packages/core/src/model/__tests__/carousel.test.ts
+++ b/packages/core/src/model/__tests__/carousel.test.ts
@@ -67,6 +67,14 @@ function motion(
   };
 }
 
+function makeItem(x = 0, y = 0, scale = 1, velocity = 0, logVelocity = 0) {
+  return {
+    x: { value: x, velocity, lastUpdatedAt: 0 },
+    y: { value: y, velocity, lastUpdatedAt: 0 },
+    scale: { value: scale, logVelocity, lastUpdatedAt: 0 },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Initial state
 // ---------------------------------------------------------------------------
@@ -104,14 +112,22 @@ describe("createCarouselReduce", () => {
       expect(reduce(state, { type: "release" })).toBe(state);
     });
 
-    it("transitions to tracking on carousel pan (no itemId)", () => {
+    it("transitions to scrolling on carousel pan (no itemId)", () => {
       const reduce = makeReduce();
       const state = reduce(settled(), motion({ dx: -50 }));
-      expect(state.type).toBe("tracking");
+      expect(state.type).toBe("scrolling");
       expect(state.carousel.value).toBeCloseTo(-50);
     });
 
-    it("transitions to tracking on item motion and updates the target item", () => {
+    it("transitions to scrolling when item at scale=1 is panned (carousel moves, item stays)", () => {
+      const reduce = makeReduce();
+      const state = reduce(settled(), motion({ itemId: "a", dx: -80 }));
+      expect(state.type).toBe("scrolling");
+      expect(state.carousel.value).toBeCloseTo(-80);
+      expect(state.items.a.x.value).toBe(0);
+    });
+
+    it("transitions to focused when a zoomed-in item is panned", () => {
       const reduce = makeReduce();
       // At scale=2, item pan bounds are x ∈ [-400, 0] and y ∈ [-600, 0].
       // Start at (-50, -50) so both dx=10 and dy=5 move within bounds.
@@ -119,30 +135,37 @@ describe("createCarouselReduce", () => {
         settled(0, { a: { x: -50, y: -50, scale: 2 } }),
         motion({ itemId: "a", dx: 10, dy: 5 }),
       );
-      expect(state.type).toBe("tracking");
+      expect(state.type).toBe("focused");
+      if (state.type === "focused") expect(state.focusedItemId).toBe("a");
       expect(state.items.a.x.value).toBeCloseTo(-40);
       expect(state.items.a.y.value).toBeCloseTo(-45);
-      // Other items are untouched
       expect(state.items.b.x.value).toBe(0);
     });
 
-    it("ignores motion events with an unknown itemId (returns same state reference)", () => {
+    it("transitions to focused on pinch (dScale != 1), even when item is at scale=1", () => {
       const reduce = makeReduce();
-      const before = settled();
-      const after = reduce(before, motion({ itemId: "unknown", dx: 10 }));
-      expect(after).toBe(before);
+      const state = reduce(settled(), motion({ itemId: "a", dScale: 1.5 }));
+      expect(state.type).toBe("focused");
+      if (state.type === "focused") expect(state.focusedItemId).toBe("a");
+    });
+
+    it("treats unknown itemId as carousel motion", () => {
+      const reduce = makeReduce();
+      const state = reduce(settled(), motion({ itemId: "unknown", dx: -30 }));
+      expect(state.type).toBe("scrolling");
+      expect(state.carousel.value).toBeCloseTo(-30);
     });
   });
 
   // -------------------------------------------------------------------------
-  // tracking state
+  // scrolling state
   // -------------------------------------------------------------------------
 
-  describe("tracking state", () => {
+  describe("scrolling state", () => {
     it("returns the same reference on tick", () => {
       const reduce = makeReduce();
       const state = reduce(settled(), motion({ dx: -10 }));
-      expect(state.type).toBe("tracking");
+      expect(state.type).toBe("scrolling");
       const next = reduce(state, { type: "tick", timestamp: 16 });
       expect(next).toBe(state);
     });
@@ -184,66 +207,106 @@ describe("createCarouselReduce", () => {
       }
     });
 
-    it("item snap targets are all at neutral {x:0, y:0, scale:1}", () => {
+    it("transitions to focused on pinch mid-scroll", () => {
       const reduce = makeReduce();
-      let state = reduce(
-        settled(),
-        motion({ itemId: "b", dScale: 2, originX: 0, originY: 0 }),
-      );
-      state = reduce(state, { type: "release" });
-      if (state.type === "snapping") {
-        expect(state.itemTargets.a).toEqual({ x: 0, y: 0, scale: 1 });
-        expect(state.itemTargets.b).toEqual({ x: 0, y: 0, scale: 1 });
-      }
+      let state = reduce(settled(), motion({ dx: -50 }));
+      expect(state.type).toBe("scrolling");
+      state = reduce(state, motion({ itemId: "a", dScale: 1.5 }));
+      expect(state.type).toBe("focused");
     });
   });
 
   // -------------------------------------------------------------------------
-  // Item overflow → carousel
+  // focused state
   // -------------------------------------------------------------------------
 
-  describe("item overflow to carousel", () => {
-    it("pan within item bounds does not affect carousel", () => {
+  describe("focused state", () => {
+    function makeFocusedState(
+      aConfig: { x: number; y: number; scale: number } = {
+        x: -50,
+        y: -50,
+        scale: 2,
+      },
+    ): CarouselPrivateState {
+      return {
+        type: "focused",
+        focusedItemId: "a",
+        carousel: { value: 0, velocity: 0, lastUpdatedAt: 0 },
+        items: {
+          a: makeItem(aConfig.x, aConfig.y, aConfig.scale),
+          b: makeItem(),
+          c: makeItem(),
+        },
+      };
+    }
+
+    it("returns the same reference on tick", () => {
       const reduce = makeReduce();
-      // At scale 2, item can pan in [-400, 0]. dx = -100 stays within bounds.
-      const state = reduce(
-        settled(0, { a: { x: 0, y: 0, scale: 2 } }),
-        motion({ itemId: "a", dx: -100 }),
-      );
-      expect(state.carousel.value).toBeCloseTo(0);
-      expect(state.items.a.x.value).toBeCloseTo(-100);
+      const state = makeFocusedState();
+      expect(reduce(state, { type: "tick", timestamp: 16 })).toBe(state);
     });
 
-    it("overflow pan beyond item left bound transfers to carousel", () => {
+    it("applies motion to the focused item", () => {
       const reduce = makeReduce();
-      // At scale 2, item bounds are [-400, 0]. Starting at x=-400 (left edge), any leftward pan overflows.
       const state = reduce(
-        settled(0, { a: { x: -400, y: 0, scale: 2 } }),
-        motion({ itemId: "a", dx: -50 }),
+        makeFocusedState(),
+        motion({ itemId: "a", dx: 10, dy: 5 }),
       );
-      // Item stays clamped at minX = ITEM_WIDTH * (1 - 2) = -400
-      expect(state.items.a.x.value).toBeCloseTo(-400);
-      // Overflow of -50 is forwarded to the carousel
-      expect(state.carousel.value).toBeCloseTo(-50);
+      expect(state.type).toBe("focused");
+      expect(state.items.a.x.value).toBeCloseTo(-40);
+      expect(state.items.a.y.value).toBeCloseTo(-45);
     });
 
-    it("overflow pan beyond item right bound transfers to carousel", () => {
+    it("does not move non-focused items", () => {
       const reduce = makeReduce();
-      // At scale 2, item bounds are [-400, 0]. Starting at x=0 (right edge), any rightward pan overflows.
-      const state = reduce(
-        settled(0, { a: { x: 0, y: 0, scale: 2 } }),
-        motion({ itemId: "a", dx: 30 }),
-      );
-      expect(state.items.a.x.value).toBeCloseTo(0);
-      expect(state.carousel.value).toBeCloseTo(30);
+      const state = reduce(makeFocusedState(), motion({ itemId: "a", dx: 10 }));
+      expect(state.items.b.x.value).toBe(0);
+      expect(state.items.c.x.value).toBe(0);
     });
 
-    it("at scale 1 all pan overflows to carousel", () => {
+    it("ignores motion targeting a different item (returns same reference)", () => {
       const reduce = makeReduce();
-      const state = reduce(settled(), motion({ itemId: "a", dx: -80 }));
-      // scale=1 → bounds are [0, 0], so all dx overflows
-      expect(state.items.a.x.value).toBeCloseTo(0);
-      expect(state.carousel.value).toBeCloseTo(-80);
+      const before = makeFocusedState();
+      const after = reduce(before, motion({ itemId: "b", dx: 30 }));
+      expect(after).toBe(before);
+    });
+
+    it("ignores motion with no itemId (returns same reference)", () => {
+      const reduce = makeReduce();
+      const before = makeFocusedState();
+      const after = reduce(before, motion({ dx: 30 }));
+      expect(after).toBe(before);
+    });
+
+    it("does not move the carousel during item pan", () => {
+      const reduce = makeReduce();
+      const state = reduce(makeFocusedState(), motion({ itemId: "a", dx: 30 }));
+      expect(state.carousel.value).toBe(0);
+    });
+
+    it("discards overflow when item is panned beyond its right bound", () => {
+      const reduce = makeReduce();
+      // At scale=2, maxX=0. Item is already at x=0; panning right overflows.
+      const before = makeFocusedState({ x: 0, y: 0, scale: 2 });
+      const after = reduce(before, motion({ itemId: "a", dx: 50 }));
+      expect(after.items.a.x.value).toBeCloseTo(0); // clamped at maxX=0
+      expect(after.carousel.value).toBeCloseTo(0); // overflow is discarded
+    });
+
+    it("discards overflow when item is panned beyond its left bound", () => {
+      const reduce = makeReduce();
+      // At scale=2, minX=-400. Item is already at x=-400; panning left overflows.
+      const before = makeFocusedState({ x: -400, y: 0, scale: 2 });
+      const after = reduce(before, motion({ itemId: "a", dx: -50 }));
+      expect(after.items.a.x.value).toBeCloseTo(-400); // clamped at minX=-400
+      expect(after.carousel.value).toBeCloseTo(0); // overflow is discarded
+    });
+
+    it("transitions to inertia on release, preserving focusedItemId", () => {
+      const reduce = makeReduce();
+      const state = reduce(makeFocusedState(), { type: "release" });
+      expect(state.type).toBe("inertia");
+      if (state.type === "inertia") expect(state.focusedItemId).toBe("a");
     });
   });
 
@@ -255,101 +318,90 @@ describe("createCarouselReduce", () => {
     function makeInertiaState(): CarouselPrivateState {
       return {
         type: "inertia",
-        carousel: { value: -200, velocity: -5, lastUpdatedAt: 0 },
+        focusedItemId: "a",
+        carousel: { value: 0, velocity: 0, lastUpdatedAt: 0 },
         items: {
-          a: {
-            x: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            y: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            scale: { value: 1, logVelocity: 0, lastUpdatedAt: 0 },
-          },
-          b: {
-            x: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            y: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            scale: { value: 1, logVelocity: 0, lastUpdatedAt: 0 },
-          },
-          c: {
-            x: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            y: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            scale: { value: 1, logVelocity: 0, lastUpdatedAt: 0 },
-          },
+          a: makeItem(-50, 0, 2, -5),
+          b: makeItem(),
+          c: makeItem(),
         },
       };
     }
 
-    it("advances carousel inertia on tick when velocity is significant", () => {
+    it("advances focused item inertia on tick when velocity is significant", () => {
       const reduce = makeReduce();
       const before = makeInertiaState();
       const after = reduce(before, { type: "tick", timestamp: 16 });
       expect(after.type).toBe("inertia");
-      expect(after.carousel.value).toBeLessThan(-200);
+      expect(after.items.a.x.value).toBeLessThan(-50);
     });
 
-    it("transitions to settled on tick when velocity decays and already at snap target", () => {
+    it("does not move the carousel during inertia", () => {
       const reduce = makeReduce();
-      // At x=0 with no velocity — already at snap target 0, all items neutral
+      const after = reduce(makeInertiaState(), { type: "tick", timestamp: 16 });
+      expect(after.carousel.value).toBe(0);
+    });
+
+    it("does not move non-focused items during inertia", () => {
+      const reduce = makeReduce();
+      const after = reduce(makeInertiaState(), { type: "tick", timestamp: 16 });
+      expect(after.items.b.x.value).toBe(0);
+    });
+
+    it("transitions to settled when focused item velocity decays", () => {
+      const reduce = makeReduce();
+      // No velocity on item a → should settle immediately
       const state: CarouselPrivateState = {
         type: "inertia",
+        focusedItemId: "a",
         carousel: { value: 0, velocity: 0, lastUpdatedAt: 0 },
         items: {
-          a: {
-            x: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            y: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            scale: { value: 1, logVelocity: 0, lastUpdatedAt: 0 },
-          },
-          b: {
-            x: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            y: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            scale: { value: 1, logVelocity: 0, lastUpdatedAt: 0 },
-          },
-          c: {
-            x: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            y: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            scale: { value: 1, logVelocity: 0, lastUpdatedAt: 0 },
-          },
+          a: makeItem(-50, 0, 2),
+          b: makeItem(),
+          c: makeItem(),
         },
       };
       const next = reduce(state, { type: "tick", timestamp: 16 });
       expect(next.type).toBe("settled");
     });
 
-    it("transitions to snapping on tick when velocity decays and snap target is far", () => {
+    it("item stays at its current position after settling (no snap to neutral)", () => {
       const reduce = makeReduce();
-      // At x=-210, no velocity — snap target is -400, gap is 190 > SNAP_THRESHOLD
       const state: CarouselPrivateState = {
         type: "inertia",
-        carousel: { value: -210, velocity: 0, lastUpdatedAt: 0 },
+        focusedItemId: "a",
+        carousel: { value: 0, velocity: 0, lastUpdatedAt: 0 },
         items: {
-          a: {
-            x: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            y: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            scale: { value: 1, logVelocity: 0, lastUpdatedAt: 0 },
-          },
-          b: {
-            x: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            y: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            scale: { value: 1, logVelocity: 0, lastUpdatedAt: 0 },
-          },
-          c: {
-            x: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            y: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            scale: { value: 1, logVelocity: 0, lastUpdatedAt: 0 },
-          },
+          a: makeItem(-50, -30, 2),
+          b: makeItem(),
+          c: makeItem(),
         },
       };
       const next = reduce(state, { type: "tick", timestamp: 16 });
-      expect(next.type).toBe("snapping");
+      expect(next.type).toBe("settled");
+      expect(next.items.a.x.value).toBeCloseTo(-50);
+      expect(next.items.a.y.value).toBeCloseTo(-30);
+      expect(next.items.a.scale.value).toBeCloseTo(2);
     });
 
-    it("transitions to tracking on motion", () => {
+    it("stays in inertia on release (returns same reference)", () => {
+      const reduce = makeReduce();
+      const state = makeInertiaState();
+      expect(reduce(state, { type: "release" })).toBe(state);
+    });
+
+    it("transitions to scrolling on carousel motion", () => {
       const reduce = makeReduce();
       const next = reduce(makeInertiaState(), motion({ dx: -30 }));
-      expect(next.type).toBe("tracking");
+      expect(next.type).toBe("scrolling");
     });
 
-    it("transitions to snapping on release", () => {
+    it("transitions to focused on pinch", () => {
       const reduce = makeReduce();
-      const next = reduce(makeInertiaState(), { type: "release" });
-      expect(next.type).toBe("snapping");
+      // Item a is at scale=2 > 1, so motion on it resolves to focused
+      const next = reduce(makeInertiaState(), motion({ itemId: "a", dx: 10 }));
+      expect(next.type).toBe("focused");
+      if (next.type === "focused") expect(next.focusedItemId).toBe("a");
     });
   });
 
@@ -367,31 +419,14 @@ describe("createCarouselReduce", () => {
         carousel: { value: carouselX, velocity: 0, lastUpdatedAt: 0 },
         carouselTarget,
         items: {
-          a: {
-            x: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            y: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            scale: { value: 1.5, logVelocity: 0, lastUpdatedAt: 0 },
-          },
-          b: {
-            x: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            y: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            scale: { value: 1, logVelocity: 0, lastUpdatedAt: 0 },
-          },
-          c: {
-            x: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            y: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            scale: { value: 1, logVelocity: 0, lastUpdatedAt: 0 },
-          },
-        },
-        itemTargets: {
-          a: { x: 0, y: 0, scale: 1 },
-          b: { x: 0, y: 0, scale: 1 },
-          c: { x: 0, y: 0, scale: 1 },
+          a: makeItem(-50, 0, 1.5),
+          b: makeItem(),
+          c: makeItem(),
         },
       };
     }
 
-    it("advances spring on tick when far from target", () => {
+    it("advances carousel spring on tick when far from target", () => {
       const reduce = makeReduce();
       const after = reduce(makeSnappingState(-200, -400), {
         type: "tick",
@@ -402,34 +437,38 @@ describe("createCarouselReduce", () => {
       expect(after.carousel.value).toBeGreaterThan(-400);
     });
 
-    it("springs item scale toward 1", () => {
+    it("items do not spring during snapping (stay at current position)", () => {
       const reduce = makeReduce();
       const after = reduce(makeSnappingState(), {
         type: "tick",
         timestamp: 16,
       });
       if (after.type === "snapping") {
-        expect(after.items.a.scale.value).toBeLessThan(1.5);
-        expect(after.items.a.scale.value).toBeGreaterThan(1);
+        expect(after.items.a.scale.value).toBe(1.5); // unchanged
+        expect(after.items.a.x.value).toBe(-50); // unchanged
       }
     });
 
-    it("transitions to settled when within snap threshold", () => {
+    it("transitions to settled when carousel is within snap threshold", () => {
       const reduce = makeReduce();
-      // Carousel is already very close to target
       const state = makeSnappingState(-399.9, -400);
-      // Override item scale to be near 1 as well
-      (state.items.a.scale as { value: number }).value = 1.005;
       const after = reduce(state, { type: "tick", timestamp: 16 });
       expect(after.type).toBe("settled");
       expect(after.carousel.value).toBeCloseTo(-400);
     });
 
+    it("items stay at their current positions on settling (no reset to neutral)", () => {
+      const reduce = makeReduce();
+      const state = makeSnappingState(-399.9, -400);
+      const after = reduce(state, { type: "tick", timestamp: 16 });
+      expect(after.type).toBe("settled");
+      expect(after.items.a.scale.value).toBe(1.5);
+      expect(after.items.a.x.value).toBe(-50);
+    });
+
     it("converges carousel to snap target over many frames", () => {
       const reduce = makeReduce();
       let state: CarouselPrivateState = makeSnappingState(-200, -400);
-      // Override item to avoid blocking convergence
-      (state.items.a.scale as { value: number }).value = 1;
       for (let i = 1; i <= 300; i++) {
         state = reduce(state, { type: "tick", timestamp: i * 16 });
         if (state.type === "settled") break;
@@ -438,53 +477,27 @@ describe("createCarouselReduce", () => {
       expect(state.carousel.value).toBeCloseTo(-400, 0);
     });
 
-    it("converges item scale to 1 over many frames", () => {
-      const reduce = makeReduce();
-      let state: CarouselPrivateState = {
-        type: "snapping",
-        carousel: { value: -400, velocity: 0, lastUpdatedAt: 0 },
-        carouselTarget: -400,
-        items: {
-          a: {
-            x: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            y: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            scale: { value: 2, logVelocity: 0, lastUpdatedAt: 0 },
-          },
-          b: {
-            x: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            y: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            scale: { value: 1, logVelocity: 0, lastUpdatedAt: 0 },
-          },
-          c: {
-            x: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            y: { value: 0, velocity: 0, lastUpdatedAt: 0 },
-            scale: { value: 1, logVelocity: 0, lastUpdatedAt: 0 },
-          },
-        },
-        itemTargets: {
-          a: { x: 0, y: 0, scale: 1 },
-          b: { x: 0, y: 0, scale: 1 },
-          c: { x: 0, y: 0, scale: 1 },
-        },
-      };
-      for (let i = 1; i <= 300; i++) {
-        state = reduce(state, { type: "tick", timestamp: i * 16 });
-        if (state.type === "settled") break;
-      }
-      expect(state.type).toBe("settled");
-      expect(state.items.a.scale.value).toBeCloseTo(1, 1);
-    });
-
-    it("stays snapping on release", () => {
+    it("stays snapping on release (returns same reference)", () => {
       const reduce = makeReduce();
       const state = makeSnappingState();
       expect(reduce(state, { type: "release" })).toBe(state);
     });
 
-    it("transitions to tracking on motion", () => {
+    it("transitions to scrolling on motion without itemId", () => {
       const reduce = makeReduce();
       const after = reduce(makeSnappingState(), motion({ dx: -20 }));
-      expect(after.type).toBe("tracking");
+      expect(after.type).toBe("scrolling");
+    });
+
+    it("transitions to focused when a zoomed-in item is panned during snapping", () => {
+      const reduce = makeReduce();
+      // Item a is at scale=1.5 > 1, so motion on it resolves to focused
+      const after = reduce(
+        makeSnappingState(),
+        motion({ itemId: "a", dx: 10 }),
+      );
+      expect(after.type).toBe("focused");
+      if (after.type === "focused") expect(after.focusedItemId).toBe("a");
     });
   });
 

--- a/packages/core/src/model/carousel.ts
+++ b/packages/core/src/model/carousel.ts
@@ -9,7 +9,6 @@ import {
   advanceLinearInertia,
   advanceExponentialInertia,
   advanceLinearSpring,
-  advanceExponentialSpring,
 } from "./primitives.js";
 
 // ---------------------------------------------------------------------------
@@ -49,15 +48,31 @@ type ItemTransform = {
  * The phase is global: a single discriminant covers both the carousel strip and all items.
  * This keeps the state machine manageable — per-item phases would multiply the number of
  * possible state combinations exponentially.
+ *
+ * States:
+ *   scrolling — carousel strip is being scrolled; items are not transformed.
+ *   focused   — one specific item is receiving gesture input (pinch or pan while zoomed in).
+ *   inertia   — the focused item is coasting after the gesture was released.
+ *   snapping  — the carousel strip is spring-snapping to the nearest item boundary.
+ *   settled   — everything is at rest.
  */
 export type CarouselPrivateState =
   | {
-      type: "tracking";
+      type: "scrolling";
+      carousel: LinearPrimitive;
+      items: Record<string, ItemTransform>;
+    }
+  | {
+      type: "focused";
+      /** The item currently receiving gesture input. */
+      focusedItemId: string;
       carousel: LinearPrimitive;
       items: Record<string, ItemTransform>;
     }
   | {
       type: "inertia";
+      /** The item coasting after the gesture was released. */
+      focusedItemId: string;
       carousel: LinearPrimitive;
       items: Record<string, ItemTransform>;
     }
@@ -66,8 +81,6 @@ export type CarouselPrivateState =
       carousel: LinearPrimitive;
       carouselTarget: number;
       items: Record<string, ItemTransform>;
-      /** Each item snaps back to its neutral position (x=0, y=0, scale=1). */
-      itemTargets: Record<string, { x: number; y: number; scale: number }>;
     }
   | {
       type: "settled";
@@ -82,7 +95,6 @@ type MotionEvent = Extract<InterpreterEvent, { type: "motion" }>;
 // ---------------------------------------------------------------------------
 
 const SNAP_THRESHOLD = 0.5; // px
-const SCALE_SNAP_THRESHOLD = 0.01; // relative (1%)
 const VELOCITY_THRESHOLD = 0.01; // px/ms
 const LOG_VELOCITY_THRESHOLD = 0.0001; // log-units/ms
 
@@ -117,15 +129,14 @@ function getItemBounds(
 
 /**
  * Applies a motion event to an item's transform, clamping translation to the item's
- * pan bounds. Any horizontal translation that exceeds the bounds is returned as
- * `overflowDx` so the caller can redirect it to the carousel strip.
+ * pan bounds. Overflow beyond the bounds is discarded.
  */
 function applyMotionToItem(
   item: ItemTransform,
   motion: MotionEvent,
   itemWidth: number,
   itemHeight: number,
-): { item: ItemTransform; overflowDx: number } {
+): ItemTransform {
   const { dx, dy, dScale, originX, originY, timestamp } = motion;
   const tx = item.x.value;
   const ty = item.y.value;
@@ -138,44 +149,45 @@ function applyMotionToItem(
   const bounds = getItemBounds(newScale, itemWidth, itemHeight);
   const clampedTx = Math.max(bounds.minX, Math.min(bounds.maxX, proposedTx));
   const clampedTy = Math.max(bounds.minY, Math.min(bounds.maxY, proposedTy));
-  const overflowDx = proposedTx - clampedTx;
 
   return {
-    item: {
-      x: applyLinearDelta(item.x, clampedTx - tx, timestamp),
-      y: applyLinearDelta(item.y, clampedTy - ty, timestamp),
-      scale: applyExponentialFactor(item.scale, dScale, timestamp),
-    },
-    overflowDx,
+    x: applyLinearDelta(item.x, clampedTx - tx, timestamp),
+    y: applyLinearDelta(item.y, clampedTy - ty, timestamp),
+    scale: applyExponentialFactor(item.scale, dScale, timestamp),
   };
 }
 
 /**
- * Applies a carousel-level motion event (no itemId) to the carousel strip.
- * Only the horizontal component (dx) is applied; dScale is ignored for the strip.
+ * Determines whether a motion event should enter the "focused" state (item transform)
+ * or the "scrolling" state (carousel scroll).
+ *
+ * Enters "focused" when the gesture targets an item that is already zoomed in,
+ * or when the gesture itself includes a scale change (pinch).
  */
-function applyMotionToCarousel(
-  carousel: LinearPrimitive,
-  motion: MotionEvent,
-): LinearPrimitive {
-  return applyLinearDelta(carousel, motion.dx, motion.timestamp);
-}
-
-function hasSignificantVelocity(
-  carousel: LinearPrimitive,
+function resolveMotionTarget(
+  action: MotionEvent,
   items: Record<string, ItemTransform>,
-): boolean {
-  if (Math.abs(carousel.velocity) > VELOCITY_THRESHOLD) return true;
-  for (const item of Object.values(items)) {
-    if (
-      Math.abs(item.x.velocity) > VELOCITY_THRESHOLD ||
-      Math.abs(item.y.velocity) > VELOCITY_THRESHOLD ||
-      Math.abs(item.scale.logVelocity) > LOG_VELOCITY_THRESHOLD
-    ) {
-      return true;
+): { type: "focused"; itemId: string } | { type: "scrolling" } {
+  if (action.itemId !== undefined) {
+    const item = items[action.itemId];
+    if (item && (action.dScale !== 1 || item.scale.value > 1)) {
+      return { type: "focused", itemId: action.itemId };
     }
   }
-  return false;
+  return { type: "scrolling" };
+}
+
+function focusedItemHasSignificantVelocity(
+  items: Record<string, ItemTransform>,
+  focusedItemId: string,
+): boolean {
+  const item = items[focusedItemId];
+  if (!item) return false;
+  return (
+    Math.abs(item.x.velocity) > VELOCITY_THRESHOLD ||
+    Math.abs(item.y.velocity) > VELOCITY_THRESHOLD ||
+    Math.abs(item.scale.logVelocity) > LOG_VELOCITY_THRESHOLD
+  );
 }
 
 function computeCarouselSnapTarget(
@@ -188,98 +200,45 @@ function computeCarouselSnapTarget(
   return Math.max(-(itemCount - 1) * itemWidth, Math.min(0, nearest));
 }
 
-function makeItemTargets(
-  itemIds: readonly string[],
-): Record<string, { x: number; y: number; scale: number }> {
-  const targets: Record<string, { x: number; y: number; scale: number }> = {};
-  for (const id of itemIds) {
-    targets[id] = { x: 0, y: 0, scale: 1 };
-  }
-  return targets;
-}
-
 function isCarouselSettled(carousel: LinearPrimitive, target: number): boolean {
   return Math.abs(carousel.value - target) < SNAP_THRESHOLD;
 }
 
-function areItemsSettled(
+function advanceFocusedItemInertia(
   items: Record<string, ItemTransform>,
-  targets: Record<string, { x: number; y: number; scale: number }>,
-): boolean {
-  for (const [id, item] of Object.entries(items)) {
-    const target = targets[id];
-    if (!target) continue;
-    if (
-      Math.abs(item.x.value - target.x) >= SNAP_THRESHOLD ||
-      Math.abs(item.y.value - target.y) >= SNAP_THRESHOLD ||
-      Math.abs(item.scale.value - target.scale) >= SCALE_SNAP_THRESHOLD
-    ) {
-      return false;
-    }
-  }
-  return true;
-}
-
-function advanceInertia(
-  carousel: LinearPrimitive,
-  items: Record<string, ItemTransform>,
+  focusedItemId: string,
   timestamp: number,
-): { carousel: LinearPrimitive; items: Record<string, ItemTransform> } {
-  const newItems: Record<string, ItemTransform> = {};
-  for (const [id, item] of Object.entries(items)) {
-    newItems[id] = {
+): Record<string, ItemTransform> {
+  const item = items[focusedItemId];
+  if (!item) return items;
+  return {
+    ...items,
+    [focusedItemId]: {
       x: advanceLinearInertia(item.x, timestamp),
       y: advanceLinearInertia(item.y, timestamp),
       scale: advanceExponentialInertia(item.scale, timestamp),
-    };
-  }
-  return {
-    carousel: advanceLinearInertia(carousel, timestamp),
-    items: newItems,
+    },
   };
 }
 
-function advanceSpring(
-  carousel: LinearPrimitive,
-  carouselTarget: number,
+function settleFocusedItem(
   items: Record<string, ItemTransform>,
-  itemTargets: Record<string, { x: number; y: number; scale: number }>,
+  focusedItemId: string,
   timestamp: number,
-): { carousel: LinearPrimitive; items: Record<string, ItemTransform> } {
-  const newItems: Record<string, ItemTransform> = {};
-  for (const [id, item] of Object.entries(items)) {
-    const target = itemTargets[id] ?? { x: 0, y: 0, scale: 1 };
-    newItems[id] = {
-      x: advanceLinearSpring(item.x, target.x, timestamp),
-      y: advanceLinearSpring(item.y, target.y, timestamp),
-      scale: advanceExponentialSpring(item.scale, target.scale, timestamp),
-    };
-  }
+): Record<string, ItemTransform> {
+  const item = items[focusedItemId];
+  if (!item) return items;
   return {
-    carousel: advanceLinearSpring(carousel, carouselTarget, timestamp),
-    items: newItems,
-  };
-}
-
-/** Snap carousel and all items exactly to their target values. */
-function settleToTargets(
-  carouselTarget: number,
-  items: Record<string, ItemTransform>,
-  itemTargets: Record<string, { x: number; y: number; scale: number }>,
-  timestamp: number,
-): { carousel: LinearPrimitive; items: Record<string, ItemTransform> } {
-  const settledItems: Record<string, ItemTransform> = {};
-  for (const [id] of Object.entries(items)) {
-    const target = itemTargets[id] ?? { x: 0, y: 0, scale: 1 };
-    settledItems[id] = {
-      x: { value: target.x, velocity: 0, lastUpdatedAt: timestamp },
-      y: { value: target.y, velocity: 0, lastUpdatedAt: timestamp },
-      scale: { value: target.scale, logVelocity: 0, lastUpdatedAt: timestamp },
-    };
-  }
-  return {
-    carousel: { value: carouselTarget, velocity: 0, lastUpdatedAt: timestamp },
-    items: settledItems,
+    ...items,
+    [focusedItemId]: {
+      x: { value: item.x.value, velocity: 0, lastUpdatedAt: timestamp },
+      y: { value: item.y.value, velocity: 0, lastUpdatedAt: timestamp },
+      scale: {
+        value: item.scale.value,
+        logVelocity: 0,
+        lastUpdatedAt: timestamp,
+      },
+    },
   };
 }
 
@@ -321,43 +280,55 @@ export function createCarouselReduce(
     return items;
   }
 
+  function applyScrollingMotion(
+    carousel: LinearPrimitive,
+    action: MotionEvent,
+  ): LinearPrimitive {
+    return applyLinearDelta(carousel, action.dx, action.timestamp);
+  }
+
   /**
-   * Handles a motion event for any phase that transitions to / stays in tracking.
-   * Returns the updated carousel and items, dispatching item-level motions with
-   * overflow pan redirected to the carousel strip.
-   * Returns null when the event carries an unknown itemId — the caller should
-   * treat this as a no-op and return the current state unchanged.
+   * Applies a motion event to the focused item only. Returns null when the event
+   * does not target the focused item (caller should treat this as a no-op).
    */
-  function applyMotion(
+  function applyFocusedMotion(
+    items: Record<string, ItemTransform>,
+    focusedItemId: string,
+    action: MotionEvent,
+  ): Record<string, ItemTransform> | null {
+    if (action.itemId !== focusedItemId) return null;
+    const item = items[focusedItemId];
+    if (!item) return null;
+    return {
+      ...items,
+      [focusedItemId]: applyMotionToItem(item, action, itemWidth, itemHeight),
+    };
+  }
+
+  /**
+   * Handles a motion event from any state that can freely transition to either
+   * "scrolling" or "focused". Applies the motion and returns the resulting state.
+   */
+  function applyMotionFromAnyState(
     carousel: LinearPrimitive,
     items: Record<string, ItemTransform>,
     action: MotionEvent,
-  ): {
-    carousel: LinearPrimitive;
-    items: Record<string, ItemTransform>;
-  } | null {
-    if (action.itemId !== undefined) {
-      const item = items[action.itemId];
-      // Unknown item ID — signal no-op to the caller.
-      if (!item) return null;
-
-      const { item: newItem, overflowDx } = applyMotionToItem(
-        item,
-        action,
-        itemWidth,
-        itemHeight,
-      );
-      const newCarousel =
-        overflowDx !== 0
-          ? applyLinearDelta(carousel, overflowDx, action.timestamp)
-          : carousel;
-      return {
-        carousel: newCarousel,
-        items: { ...items, [action.itemId]: newItem },
-      };
+  ): CarouselPrivateState {
+    const target = resolveMotionTarget(action, items);
+    if (target.type === "focused") {
+      const newItems = applyFocusedMotion(items, target.itemId, action);
+      if (newItems) {
+        return {
+          type: "focused",
+          focusedItemId: target.itemId,
+          carousel,
+          items: newItems,
+        };
+      }
     }
     return {
-      carousel: applyMotionToCarousel(carousel, action),
+      type: "scrolling",
+      carousel: applyScrollingMotion(carousel, action),
       items,
     };
   }
@@ -371,12 +342,29 @@ export function createCarouselReduce(
     action: StoreAction,
   ): CarouselPrivateState {
     switch (state.type) {
-      case "tracking": {
+      case "scrolling": {
         switch (action.type) {
           case "motion": {
-            const result = applyMotion(state.carousel, state.items, action);
-            if (!result) return state;
-            return { ...state, carousel: result.carousel, items: result.items };
+            const target = resolveMotionTarget(action, state.items);
+            if (target.type === "focused") {
+              const newItems = applyFocusedMotion(
+                state.items,
+                target.itemId,
+                action,
+              );
+              if (newItems) {
+                return {
+                  type: "focused",
+                  focusedItemId: target.itemId,
+                  carousel: state.carousel,
+                  items: newItems,
+                };
+              }
+            }
+            return {
+              ...state,
+              carousel: applyScrollingMotion(state.carousel, action),
+            };
           }
           case "release": {
             const carouselTarget = computeCarouselSnapTarget(
@@ -385,10 +373,10 @@ export function createCarouselReduce(
               itemIds.length,
             );
             return {
-              ...state,
               type: "snapping",
+              carousel: state.carousel,
               carouselTarget,
-              itemTargets: makeItemTargets(itemIds),
+              items: state.items,
             };
           }
           case "tick":
@@ -396,113 +384,100 @@ export function createCarouselReduce(
         }
         throw new Error("unreachable");
       }
-      case "inertia": {
+      case "focused": {
         switch (action.type) {
           case "motion": {
-            const result = applyMotion(state.carousel, state.items, action);
-            if (!result) return state;
-            return {
-              ...state,
-              type: "tracking",
-              carousel: result.carousel,
-              items: result.items,
-            };
-          }
-          case "release": {
-            const carouselTarget = computeCarouselSnapTarget(
-              state.carousel.value,
-              itemWidth,
-              itemIds.length,
+            // Only handle motion targeting the focused item; ignore everything else.
+            const newItems = applyFocusedMotion(
+              state.items,
+              state.focusedItemId,
+              action,
             );
-            return {
-              ...state,
-              type: "snapping",
-              carouselTarget,
-              itemTargets: makeItemTargets(itemIds),
-            };
+            if (!newItems) return state;
+            return { ...state, items: newItems };
           }
+          case "release":
+            return {
+              type: "inertia",
+              focusedItemId: state.focusedItemId,
+              carousel: state.carousel,
+              items: state.items,
+            };
+          case "tick":
+            return state;
+        }
+        throw new Error("unreachable");
+      }
+      case "inertia": {
+        switch (action.type) {
+          case "motion":
+            return applyMotionFromAnyState(state.carousel, state.items, action);
+          case "release":
+            return state;
           case "tick": {
-            if (hasSignificantVelocity(state.carousel, state.items)) {
-              const { carousel, items } = advanceInertia(
-                state.carousel,
-                state.items,
-                action.timestamp,
-              );
-              return { ...state, carousel, items };
-            }
-            const carouselTarget = computeCarouselSnapTarget(
-              state.carousel.value,
-              itemWidth,
-              itemIds.length,
-            );
-            const itemTargets = makeItemTargets(itemIds);
             if (
-              isCarouselSettled(state.carousel, carouselTarget) &&
-              areItemsSettled(state.items, itemTargets)
-            ) {
-              const { carousel, items } = settleToTargets(
-                carouselTarget,
+              focusedItemHasSignificantVelocity(
                 state.items,
-                itemTargets,
-                action.timestamp,
-              );
-              return { type: "settled", carousel, items };
+                state.focusedItemId,
+              )
+            ) {
+              return {
+                ...state,
+                items: advanceFocusedItemInertia(
+                  state.items,
+                  state.focusedItemId,
+                  action.timestamp,
+                ),
+              };
             }
-            return { ...state, type: "snapping", carouselTarget, itemTargets };
+            return {
+              type: "settled",
+              carousel: state.carousel,
+              items: settleFocusedItem(
+                state.items,
+                state.focusedItemId,
+                action.timestamp,
+              ),
+            };
           }
         }
         throw new Error("unreachable");
       }
       case "snapping": {
         switch (action.type) {
-          case "motion": {
-            const result = applyMotion(state.carousel, state.items, action);
-            if (!result) return state;
-            return {
-              type: "tracking",
-              carousel: result.carousel,
-              items: result.items,
-            };
-          }
+          case "motion":
+            return applyMotionFromAnyState(state.carousel, state.items, action);
           case "release":
             return state;
           case "tick": {
-            const { carouselTarget, itemTargets } = state;
-            if (
-              isCarouselSettled(state.carousel, carouselTarget) &&
-              areItemsSettled(state.items, itemTargets)
-            ) {
-              const { carousel, items } = settleToTargets(
-                carouselTarget,
-                state.items,
-                itemTargets,
-                action.timestamp,
-              );
-              return { type: "settled", carousel, items };
+            const { carouselTarget } = state;
+            if (isCarouselSettled(state.carousel, carouselTarget)) {
+              return {
+                type: "settled",
+                carousel: {
+                  value: carouselTarget,
+                  velocity: 0,
+                  lastUpdatedAt: action.timestamp,
+                },
+                items: state.items,
+              };
             }
-            const { carousel, items } = advanceSpring(
-              state.carousel,
-              carouselTarget,
-              state.items,
-              itemTargets,
-              action.timestamp,
-            );
-            return { ...state, carousel, items };
+            return {
+              ...state,
+              carousel: advanceLinearSpring(
+                state.carousel,
+                carouselTarget,
+                action.timestamp,
+              ),
+            };
           }
         }
         throw new Error("unreachable");
       }
       case "settled": {
         switch (action.type) {
-          case "motion": {
-            const result = applyMotion(state.carousel, state.items, action);
-            if (!result) return state;
-            return {
-              type: "tracking",
-              carousel: result.carousel,
-              items: result.items,
-            };
-          }
+          case "motion":
+            return applyMotionFromAnyState(state.carousel, state.items, action);
           case "release":
             return state;
           case "tick":


### PR DESCRIPTION
## Summary

- Renames `tracking` → `scrolling` (carousel-level scroll only; items are never transformed here)
- Adds `focused` state with `focusedItemId` — entered when the gesture targets a zoomed-in item or includes a pinch (`dScale ≠ 1`); only the focused item moves, overflow is discarded instead of flowing to the carousel
- `inertia` now carries `focusedItemId`; only the focused item coasts after release, carousel stays put
- Removes `itemTargets` from `snapping` — items stay at their current position/scale after settling (no snap-to-neutral)

## State transition rules

| From | Motion condition | → To |
|------|-----------------|-------|
| any | `itemId` present AND (`dScale ≠ 1` OR `item.scale > 1`) | `focused` |
| any | everything else | `scrolling` |
| `focused` | motion not targeting `focusedItemId` | (ignored) |
| `scrolling` | release | `snapping` |
| `focused` | release | `inertia` |
| `inertia` | velocity decays | `settled` |

## Test plan

- [ ] `npm run tsc && npm run format && npm run lint && npm run test` all pass (91 tests)
- [ ] Carousel scrolling does not transform items
- [ ] Pinch on item enters `focused` and only that item transforms
- [ ] Overflow during `focused` is discarded (carousel stays put)
- [ ] Items remain zoomed after releasing (`settled` preserves scale/position)

🤖 Generated with [Claude Code](https://claude.com/claude-code)