### PR TITLE
Refactor carousel state machine to separate carousel-level and item-level phases

### DIFF
--- a/packages/core/src/model/__tests__/carousel.test.ts
+++ b/packages/core/src/model/__tests__/carousel.test.ts
@@ -3,6 +3,7 @@ import {
   createCarouselReduce,
   toCarouselPublicState,
   type CarouselPrivateState,
+  type ItemPrivateState,
 } from "../carousel.js";
 
 const ITEM_WIDTH = 400;
@@ -17,30 +18,62 @@ function makeReduce() {
   });
 }
 
+function makeItemTransform(
+  x = 0,
+  y = 0,
+  scale = 1,
+  velocity = 0,
+  logVelocity = 0,
+) {
+  return {
+    x: { value: x, velocity, lastUpdatedAt: 0 },
+    y: { value: y, velocity, lastUpdatedAt: 0 },
+    scale: { value: scale, logVelocity, lastUpdatedAt: 0 },
+  };
+}
+
+function makeSettledItem(x = 0, y = 0, scale = 1): ItemPrivateState {
+  return { type: "settled", transform: makeItemTransform(x, y, scale) };
+}
+
+function makeInertiaItem(
+  x = 0,
+  y = 0,
+  scale = 1,
+  velocity = 0,
+): ItemPrivateState {
+  return {
+    type: "inertia",
+    transform: makeItemTransform(x, y, scale, velocity),
+  };
+}
+
+function makeTrackingItem(x = 0, y = 0, scale = 1): ItemPrivateState {
+  return { type: "tracking", transform: makeItemTransform(x, y, scale) };
+}
+
 function settled(
   carouselX = 0,
-  items: Record<string, { x: number; y: number; scale: number }> = {},
+  itemOverrides: Partial<
+    Record<string, { x?: number; y?: number; scale?: number }>
+  > = {},
 ): CarouselPrivateState {
-  const defaultItems: Record<
-    string,
-    {
-      x: { value: number; velocity: number; lastUpdatedAt: number };
-      y: { value: number; velocity: number; lastUpdatedAt: number };
-      scale: { value: number; logVelocity: number; lastUpdatedAt: number };
-    }
-  > = {};
+  const items: Record<string, ItemPrivateState> = {};
   for (const id of ITEM_IDS) {
-    const { x = 0, y = 0, scale = 1 } = items[id] ?? {};
-    defaultItems[id] = {
-      x: { value: x, velocity: 0, lastUpdatedAt: NaN },
-      y: { value: y, velocity: 0, lastUpdatedAt: NaN },
-      scale: { value: scale, logVelocity: 0, lastUpdatedAt: NaN },
+    const { x = 0, y = 0, scale = 1 } = itemOverrides[id] ?? {};
+    items[id] = {
+      type: "settled",
+      transform: {
+        x: { value: x, velocity: 0, lastUpdatedAt: NaN },
+        y: { value: y, velocity: 0, lastUpdatedAt: NaN },
+        scale: { value: scale, logVelocity: 0, lastUpdatedAt: NaN },
+      },
     };
   }
   return {
     type: "settled",
     carousel: { value: carouselX, velocity: 0, lastUpdatedAt: NaN },
-    items: defaultItems,
+    items,
   };
 }
 
@@ -67,29 +100,22 @@ function motion(
   };
 }
 
-function makeItem(x = 0, y = 0, scale = 1, velocity = 0, logVelocity = 0) {
-  return {
-    x: { value: x, velocity, lastUpdatedAt: 0 },
-    y: { value: y, velocity, lastUpdatedAt: 0 },
-    scale: { value: scale, logVelocity, lastUpdatedAt: 0 },
-  };
-}
-
 // ---------------------------------------------------------------------------
 // Initial state
 // ---------------------------------------------------------------------------
 
 describe("createCarouselReduce", () => {
   describe("initial state", () => {
-    it("starts settled with carousel at 0 and all items at neutral", () => {
+    it("starts settled with carousel at 0 and all items settled at neutral", () => {
       const reduce = makeReduce();
       const state = reduce(undefined, { type: "tick", timestamp: 0 });
       expect(state.type).toBe("settled");
       expect(state.carousel.value).toBe(0);
       for (const id of ITEM_IDS) {
-        expect(state.items[id].x.value).toBe(0);
-        expect(state.items[id].y.value).toBe(0);
-        expect(state.items[id].scale.value).toBe(1);
+        expect(state.items[id].type).toBe("settled");
+        expect(state.items[id].transform.x.value).toBe(0);
+        expect(state.items[id].transform.y.value).toBe(0);
+        expect(state.items[id].transform.scale.value).toBe(1);
       }
     });
   });
@@ -99,7 +125,7 @@ describe("createCarouselReduce", () => {
   // -------------------------------------------------------------------------
 
   describe("settled state", () => {
-    it("returns the same reference on tick (reference equality contract)", () => {
+    it("returns the same reference on tick when no items are in motion", () => {
       const reduce = makeReduce();
       const state = settled();
       const next = reduce(state, { type: "tick", timestamp: 16 });
@@ -124,29 +150,27 @@ describe("createCarouselReduce", () => {
       const state = reduce(settled(), motion({ itemId: "a", dx: -80 }));
       expect(state.type).toBe("scrolling");
       expect(state.carousel.value).toBeCloseTo(-80);
-      expect(state.items.a.x.value).toBe(0);
+      expect(state.items.a.transform.x.value).toBe(0);
     });
 
-    it("transitions to focused when a zoomed-in item is panned", () => {
+    it("transitions to locked when a zoomed-in item is panned", () => {
       const reduce = makeReduce();
-      // At scale=2, item pan bounds are x ∈ [-400, 0] and y ∈ [-600, 0].
-      // Start at (-50, -50) so both dx=10 and dy=5 move within bounds.
       const state = reduce(
         settled(0, { a: { x: -50, y: -50, scale: 2 } }),
         motion({ itemId: "a", dx: 10, dy: 5 }),
       );
-      expect(state.type).toBe("focused");
-      if (state.type === "focused") expect(state.focusedItemId).toBe("a");
-      expect(state.items.a.x.value).toBeCloseTo(-40);
-      expect(state.items.a.y.value).toBeCloseTo(-45);
-      expect(state.items.b.x.value).toBe(0);
+      expect(state.type).toBe("locked");
+      expect(state.items.a.type).toBe("tracking");
+      expect(state.items.a.transform.x.value).toBeCloseTo(-40);
+      expect(state.items.a.transform.y.value).toBeCloseTo(-45);
+      expect(state.items.b.transform.x.value).toBe(0);
     });
 
-    it("transitions to focused on pinch (dScale != 1), even when item is at scale=1", () => {
+    it("transitions to locked on pinch (dScale != 1), even when item is at scale=1", () => {
       const reduce = makeReduce();
       const state = reduce(settled(), motion({ itemId: "a", dScale: 1.5 }));
-      expect(state.type).toBe("focused");
-      if (state.type === "focused") expect(state.focusedItemId).toBe("a");
+      expect(state.type).toBe("locked");
+      expect(state.items.a.type).toBe("tracking");
     });
 
     it("treats unknown itemId as carousel motion", () => {
@@ -155,6 +179,56 @@ describe("createCarouselReduce", () => {
       expect(state.type).toBe("scrolling");
       expect(state.carousel.value).toBeCloseTo(-30);
     });
+
+    it("advances inertia items on tick (parallel operation)", () => {
+      const reduce = makeReduce();
+      const state: CarouselPrivateState = {
+        type: "settled",
+        carousel: { value: 0, velocity: 0, lastUpdatedAt: 0 },
+        items: {
+          a: makeInertiaItem(-50, 0, 2, -5),
+          b: makeSettledItem(),
+          c: makeSettledItem(),
+        },
+      };
+      const next = reduce(state, { type: "tick", timestamp: 16 });
+      expect(next.type).toBe("settled");
+      expect(next.items.a.type).toBe("inertia");
+      expect(next.items.a.transform.x.value).toBeLessThan(-50);
+    });
+
+    it("locks on an inertia item when a motion targets it", () => {
+      const reduce = makeReduce();
+      const state: CarouselPrivateState = {
+        type: "settled",
+        carousel: { value: 0, velocity: 0, lastUpdatedAt: 0 },
+        items: {
+          a: makeInertiaItem(-50, 0, 2, -5),
+          b: makeSettledItem(),
+          c: makeSettledItem(),
+        },
+      };
+      const next = reduce(state, motion({ itemId: "a", dx: 10 }));
+      expect(next.type).toBe("locked");
+      expect(next.items.a.type).toBe("tracking");
+    });
+
+    it("cancels inertia item when locking on a different item", () => {
+      const reduce = makeReduce();
+      const state: CarouselPrivateState = {
+        type: "settled",
+        carousel: { value: 0, velocity: 0, lastUpdatedAt: 0 },
+        items: {
+          a: makeInertiaItem(-50, 0, 2, -5),
+          b: makeSettledItem(0, 0, 2),
+          c: makeSettledItem(),
+        },
+      };
+      const next = reduce(state, motion({ itemId: "b", dx: 5 }));
+      expect(next.type).toBe("locked");
+      expect(next.items.a.type).toBe("settled"); // cancelled
+      expect(next.items.b.type).toBe("tracking");
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -162,7 +236,7 @@ describe("createCarouselReduce", () => {
   // -------------------------------------------------------------------------
 
   describe("scrolling state", () => {
-    it("returns the same reference on tick", () => {
+    it("returns the same reference on tick when no items are in motion", () => {
       const reduce = makeReduce();
       const state = reduce(settled(), motion({ dx: -10 }));
       expect(state.type).toBe("scrolling");
@@ -179,7 +253,6 @@ describe("createCarouselReduce", () => {
 
     it("snap target is the nearest item boundary", () => {
       const reduce = makeReduce();
-      // Swiped more than halfway to item 1 → should snap to -400
       let state = reduce(settled(), motion({ dx: -210 }));
       state = reduce(state, { type: "release" });
       expect(state.type).toBe("snapping");
@@ -199,7 +272,6 @@ describe("createCarouselReduce", () => {
 
     it("snap target is clamped to the last item boundary", () => {
       const reduce = makeReduce();
-      // Swiped well past the last item (index 2, target = -800)
       let state = reduce(settled(-800), motion({ dx: -1000 }));
       state = reduce(state, { type: "release" });
       if (state.type === "snapping") {
@@ -207,21 +279,39 @@ describe("createCarouselReduce", () => {
       }
     });
 
-    it("transitions to focused on pinch mid-scroll", () => {
+    it("does not transition to locked on pinch mid-scroll (locked only from settled)", () => {
       const reduce = makeReduce();
       let state = reduce(settled(), motion({ dx: -50 }));
       expect(state.type).toBe("scrolling");
       state = reduce(state, motion({ itemId: "a", dScale: 1.5 }));
-      expect(state.type).toBe("focused");
+      // Stays scrolling; carousel advances by dx (0 in this case)
+      expect(state.type).toBe("scrolling");
+    });
+
+    it("advances inertia items on tick while scrolling (parallel operation)", () => {
+      const reduce = makeReduce();
+      const state: CarouselPrivateState = {
+        type: "scrolling",
+        carousel: { value: -50, velocity: 0, lastUpdatedAt: 0 },
+        items: {
+          a: makeInertiaItem(-50, 0, 2, -5),
+          b: makeSettledItem(),
+          c: makeSettledItem(),
+        },
+      };
+      const next = reduce(state, { type: "tick", timestamp: 16 });
+      expect(next.type).toBe("scrolling");
+      expect(next.items.a.type).toBe("inertia");
+      expect(next.items.a.transform.x.value).toBeLessThan(-50);
     });
   });
 
   // -------------------------------------------------------------------------
-  // focused state
+  // locked state
   // -------------------------------------------------------------------------
 
-  describe("focused state", () => {
-    function makeFocusedState(
+  describe("locked state", () => {
+    function makeLockedState(
       aConfig: { x: number; y: number; scale: number } = {
         x: -50,
         y: -50,
@@ -229,187 +319,278 @@ describe("createCarouselReduce", () => {
       },
     ): CarouselPrivateState {
       return {
-        type: "focused",
-        focusedItemId: "a",
+        type: "locked",
         carousel: { value: 0, velocity: 0, lastUpdatedAt: 0 },
         items: {
-          a: makeItem(aConfig.x, aConfig.y, aConfig.scale),
-          b: makeItem(),
-          c: makeItem(),
+          a: makeTrackingItem(aConfig.x, aConfig.y, aConfig.scale),
+          b: makeSettledItem(),
+          c: makeSettledItem(),
         },
       };
     }
 
-    it("returns the same reference on tick", () => {
+    it("returns the same reference on tick when no items are animating", () => {
       const reduce = makeReduce();
-      const state = makeFocusedState();
+      const state = makeLockedState();
       expect(reduce(state, { type: "tick", timestamp: 16 })).toBe(state);
     });
 
-    it("applies motion to the focused item", () => {
+    it("applies motion to the tracking item", () => {
       const reduce = makeReduce();
       const state = reduce(
-        makeFocusedState(),
+        makeLockedState(),
         motion({ itemId: "a", dx: 10, dy: 5 }),
       );
-      expect(state.type).toBe("focused");
-      expect(state.items.a.x.value).toBeCloseTo(-40);
-      expect(state.items.a.y.value).toBeCloseTo(-45);
+      expect(state.type).toBe("locked");
+      expect(state.items.a.type).toBe("tracking");
+      expect(state.items.a.transform.x.value).toBeCloseTo(-40);
+      expect(state.items.a.transform.y.value).toBeCloseTo(-45);
     });
 
-    it("does not move non-focused items", () => {
+    it("does not move non-tracking items", () => {
       const reduce = makeReduce();
-      const state = reduce(makeFocusedState(), motion({ itemId: "a", dx: 10 }));
-      expect(state.items.b.x.value).toBe(0);
-      expect(state.items.c.x.value).toBe(0);
+      const state = reduce(makeLockedState(), motion({ itemId: "a", dx: 10 }));
+      expect(state.items.b.transform.x.value).toBe(0);
+      expect(state.items.c.transform.x.value).toBe(0);
     });
 
     it("ignores motion targeting a different item (returns same reference)", () => {
       const reduce = makeReduce();
-      const before = makeFocusedState();
+      const before = makeLockedState();
       const after = reduce(before, motion({ itemId: "b", dx: 30 }));
       expect(after).toBe(before);
     });
 
     it("ignores motion with no itemId (returns same reference)", () => {
       const reduce = makeReduce();
-      const before = makeFocusedState();
+      const before = makeLockedState();
       const after = reduce(before, motion({ dx: 30 }));
       expect(after).toBe(before);
     });
 
     it("does not move the carousel during item pan", () => {
       const reduce = makeReduce();
-      const state = reduce(makeFocusedState(), motion({ itemId: "a", dx: 30 }));
+      const state = reduce(makeLockedState(), motion({ itemId: "a", dx: 30 }));
       expect(state.carousel.value).toBe(0);
     });
 
     it("discards overflow when item is panned beyond its right bound", () => {
       const reduce = makeReduce();
-      // At scale=2, maxX=0. Item is already at x=0; panning right overflows.
-      const before = makeFocusedState({ x: 0, y: 0, scale: 2 });
+      const before = makeLockedState({ x: 0, y: 0, scale: 2 });
       const after = reduce(before, motion({ itemId: "a", dx: 50 }));
-      expect(after.items.a.x.value).toBeCloseTo(0); // clamped at maxX=0
-      expect(after.carousel.value).toBeCloseTo(0); // overflow is discarded
+      expect(after.items.a.transform.x.value).toBeCloseTo(0);
+      expect(after.carousel.value).toBeCloseTo(0);
     });
 
     it("discards overflow when item is panned beyond its left bound", () => {
       const reduce = makeReduce();
-      // At scale=2, minX=-400. Item is already at x=-400; panning left overflows.
-      const before = makeFocusedState({ x: -400, y: 0, scale: 2 });
+      const before = makeLockedState({ x: -400, y: 0, scale: 2 });
       const after = reduce(before, motion({ itemId: "a", dx: -50 }));
-      expect(after.items.a.x.value).toBeCloseTo(-400); // clamped at minX=-400
-      expect(after.carousel.value).toBeCloseTo(0); // overflow is discarded
+      expect(after.items.a.transform.x.value).toBeCloseTo(-400);
+      expect(after.carousel.value).toBeCloseTo(0);
     });
 
-    it("transitions to inertia on release, preserving focusedItemId", () => {
+    it("transitions carousel to settled on release, item transitions to inertia", () => {
       const reduce = makeReduce();
-      const state = reduce(makeFocusedState(), { type: "release" });
-      expect(state.type).toBe("inertia");
-      if (state.type === "inertia") expect(state.focusedItemId).toBe("a");
+      const state = reduce(makeLockedState(), { type: "release" });
+      expect(state.type).toBe("settled");
+      // item had no velocity → settled
+      expect(state.items.a.type).toBe("settled");
+    });
+
+    it("item transitions to inertia on release when it has significant velocity", () => {
+      const reduce = makeReduce();
+      const lockedWithVelocity: CarouselPrivateState = {
+        type: "locked",
+        carousel: { value: 0, velocity: 0, lastUpdatedAt: 0 },
+        items: {
+          a: { type: "tracking", transform: makeItemTransform(-50, 0, 2, -5) },
+          b: makeSettledItem(),
+          c: makeSettledItem(),
+        },
+      };
+      const state = reduce(lockedWithVelocity, { type: "release" });
+      expect(state.type).toBe("settled");
+      expect(state.items.a.type).toBe("inertia");
+    });
+
+    it("item transitions to snapping on release when under-zoomed", () => {
+      const reduce = makeReduce();
+      const lockedUnderZoom: CarouselPrivateState = {
+        type: "locked",
+        carousel: { value: 0, velocity: 0, lastUpdatedAt: 0 },
+        items: {
+          a: makeTrackingItem(0, 0, 0.5),
+          b: makeSettledItem(),
+          c: makeSettledItem(),
+        },
+      };
+      const state = reduce(lockedUnderZoom, { type: "release" });
+      expect(state.type).toBe("settled");
+      expect(state.items.a.type).toBe("snapping");
+      if (state.items.a.type === "snapping") {
+        expect(state.items.a.target).toEqual({ x: 0, y: 0, scale: 1 });
+      }
     });
   });
 
   // -------------------------------------------------------------------------
-  // inertia state
+  // Item-level inertia (carousel settled, item animating)
   // -------------------------------------------------------------------------
 
-  describe("inertia state", () => {
-    function makeInertiaState(): CarouselPrivateState {
+  describe("item inertia (parallel with carousel settled)", () => {
+    function makeSettledCarouselWithInertiaItem(): CarouselPrivateState {
       return {
-        type: "inertia",
-        focusedItemId: "a",
+        type: "settled",
         carousel: { value: 0, velocity: 0, lastUpdatedAt: 0 },
         items: {
-          a: makeItem(-50, 0, 2, -5),
-          b: makeItem(),
-          c: makeItem(),
+          a: makeInertiaItem(-50, 0, 2, -5),
+          b: makeSettledItem(),
+          c: makeSettledItem(),
         },
       };
     }
 
-    it("advances focused item inertia on tick when velocity is significant", () => {
+    it("advances item inertia on tick", () => {
       const reduce = makeReduce();
-      const before = makeInertiaState();
-      const after = reduce(before, { type: "tick", timestamp: 16 });
-      expect(after.type).toBe("inertia");
-      expect(after.items.a.x.value).toBeLessThan(-50);
+      const after = reduce(makeSettledCarouselWithInertiaItem(), {
+        type: "tick",
+        timestamp: 16,
+      });
+      expect(after.type).toBe("settled");
+      expect(after.items.a.type).toBe("inertia");
+      expect(after.items.a.transform.x.value).toBeLessThan(-50);
     });
 
-    it("does not move the carousel during inertia", () => {
+    it("does not move the carousel during item inertia", () => {
       const reduce = makeReduce();
-      const after = reduce(makeInertiaState(), { type: "tick", timestamp: 16 });
+      const after = reduce(makeSettledCarouselWithInertiaItem(), {
+        type: "tick",
+        timestamp: 16,
+      });
       expect(after.carousel.value).toBe(0);
     });
 
-    it("does not move non-focused items during inertia", () => {
+    it("does not move non-inertia items", () => {
       const reduce = makeReduce();
-      const after = reduce(makeInertiaState(), { type: "tick", timestamp: 16 });
-      expect(after.items.b.x.value).toBe(0);
+      const after = reduce(makeSettledCarouselWithInertiaItem(), {
+        type: "tick",
+        timestamp: 16,
+      });
+      expect(after.items.b.transform.x.value).toBe(0);
     });
 
-    it("transitions to settled when focused item velocity decays", () => {
+    it("item settles when velocity decays", () => {
       const reduce = makeReduce();
-      // No velocity on item a → should settle immediately
       const state: CarouselPrivateState = {
-        type: "inertia",
-        focusedItemId: "a",
+        type: "settled",
         carousel: { value: 0, velocity: 0, lastUpdatedAt: 0 },
         items: {
-          a: makeItem(-50, 0, 2),
-          b: makeItem(),
-          c: makeItem(),
+          a: makeInertiaItem(-50, 0, 2), // no velocity → settles immediately
+          b: makeSettledItem(),
+          c: makeSettledItem(),
         },
       };
       const next = reduce(state, { type: "tick", timestamp: 16 });
-      expect(next.type).toBe("settled");
+      expect(next.items.a.type).toBe("settled");
+      expect(next.items.a.transform.x.value).toBeCloseTo(-50);
     });
 
     it("item stays at its current position after settling (no snap to neutral)", () => {
       const reduce = makeReduce();
       const state: CarouselPrivateState = {
-        type: "inertia",
-        focusedItemId: "a",
+        type: "settled",
         carousel: { value: 0, velocity: 0, lastUpdatedAt: 0 },
         items: {
-          a: makeItem(-50, -30, 2),
-          b: makeItem(),
-          c: makeItem(),
+          a: makeInertiaItem(-50, -30, 2),
+          b: makeSettledItem(),
+          c: makeSettledItem(),
         },
       };
       const next = reduce(state, { type: "tick", timestamp: 16 });
-      expect(next.type).toBe("settled");
-      expect(next.items.a.x.value).toBeCloseTo(-50);
-      expect(next.items.a.y.value).toBeCloseTo(-30);
-      expect(next.items.a.scale.value).toBeCloseTo(2);
+      expect(next.items.a.transform.x.value).toBeCloseTo(-50);
+      expect(next.items.a.transform.y.value).toBeCloseTo(-30);
+      expect(next.items.a.transform.scale.value).toBeCloseTo(2);
     });
 
-    it("stays in inertia on release (returns same reference)", () => {
+    it("can start scrolling the carousel while item is still in inertia", () => {
       const reduce = makeReduce();
-      const state = makeInertiaState();
-      expect(reduce(state, { type: "release" })).toBe(state);
-    });
-
-    it("transitions to scrolling on carousel motion", () => {
-      const reduce = makeReduce();
-      const next = reduce(makeInertiaState(), motion({ dx: -30 }));
+      const next = reduce(
+        makeSettledCarouselWithInertiaItem(),
+        motion({ dx: -30 }),
+      );
       expect(next.type).toBe("scrolling");
+      expect(next.items.a.type).toBe("inertia"); // item continues
     });
 
-    it("transitions to focused on pinch", () => {
+    it("item transitions to snapping when inertia decays below scale=1", () => {
       const reduce = makeReduce();
-      // Item a is at scale=2 > 1, so motion on it resolves to focused
-      const next = reduce(makeInertiaState(), motion({ itemId: "a", dx: 10 }));
-      expect(next.type).toBe("focused");
-      if (next.type === "focused") expect(next.focusedItemId).toBe("a");
+      const state: CarouselPrivateState = {
+        type: "settled",
+        carousel: { value: 0, velocity: 0, lastUpdatedAt: 0 },
+        items: {
+          a: makeInertiaItem(0, 0, 0.5), // no velocity, under-zoom
+          b: makeSettledItem(),
+          c: makeSettledItem(),
+        },
+      };
+      const next = reduce(state, { type: "tick", timestamp: 16 });
+      expect(next.items.a.type).toBe("snapping");
+      if (next.items.a.type === "snapping") {
+        expect(next.items.a.target).toEqual({ x: 0, y: 0, scale: 1 });
+      }
     });
   });
 
   // -------------------------------------------------------------------------
-  // snapping state
+  // Item-level snapping (under-zoom recovery)
   // -------------------------------------------------------------------------
 
-  describe("snapping state", () => {
+  describe("item snapping (under-zoom recovery)", () => {
+    function makeSnappingItemState(): CarouselPrivateState {
+      return {
+        type: "settled",
+        carousel: { value: 0, velocity: 0, lastUpdatedAt: 0 },
+        items: {
+          a: {
+            type: "snapping",
+            transform: makeItemTransform(0, 0, 0.5),
+            target: { x: 0, y: 0, scale: 1 },
+          },
+          b: makeSettledItem(),
+          c: makeSettledItem(),
+        },
+      };
+    }
+
+    it("advances item spring toward scale=1 on tick", () => {
+      const reduce = makeReduce();
+      const after = reduce(makeSnappingItemState(), {
+        type: "tick",
+        timestamp: 16,
+      });
+      expect(after.items.a.type).toBe("snapping");
+      expect(after.items.a.transform.scale.value).toBeGreaterThan(0.5);
+      expect(after.items.a.transform.scale.value).toBeLessThan(1);
+    });
+
+    it("settles item when scale reaches target", () => {
+      const reduce = makeReduce();
+      let state = makeSnappingItemState();
+      for (let i = 1; i <= 500; i++) {
+        state = reduce(state, { type: "tick", timestamp: i * 16 });
+        if (state.items.a.type === "settled") break;
+      }
+      expect(state.items.a.type).toBe("settled");
+      expect(state.items.a.transform.scale.value).toBeCloseTo(1, 2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // snapping state (carousel-level)
+  // -------------------------------------------------------------------------
+
+  describe("snapping state (carousel)", () => {
     function makeSnappingState(
       carouselX = -200,
       carouselTarget = -400,
@@ -419,9 +600,9 @@ describe("createCarouselReduce", () => {
         carousel: { value: carouselX, velocity: 0, lastUpdatedAt: 0 },
         carouselTarget,
         items: {
-          a: makeItem(-50, 0, 1.5),
-          b: makeItem(),
-          c: makeItem(),
+          a: makeSettledItem(-50, 0, 1.5),
+          b: makeSettledItem(),
+          c: makeSettledItem(),
         },
       };
     }
@@ -437,15 +618,15 @@ describe("createCarouselReduce", () => {
       expect(after.carousel.value).toBeGreaterThan(-400);
     });
 
-    it("items do not spring during snapping (stay at current position)", () => {
+    it("items do not spring during carousel snapping (stay at current position)", () => {
       const reduce = makeReduce();
       const after = reduce(makeSnappingState(), {
         type: "tick",
         timestamp: 16,
       });
       if (after.type === "snapping") {
-        expect(after.items.a.scale.value).toBe(1.5); // unchanged
-        expect(after.items.a.x.value).toBe(-50); // unchanged
+        expect(after.items.a.transform.scale.value).toBe(1.5);
+        expect(after.items.a.transform.x.value).toBe(-50);
       }
     });
 
@@ -457,13 +638,13 @@ describe("createCarouselReduce", () => {
       expect(after.carousel.value).toBeCloseTo(-400);
     });
 
-    it("items stay at their current positions on settling (no reset to neutral)", () => {
+    it("items stay at their current positions on settling", () => {
       const reduce = makeReduce();
       const state = makeSnappingState(-399.9, -400);
       const after = reduce(state, { type: "tick", timestamp: 16 });
       expect(after.type).toBe("settled");
-      expect(after.items.a.scale.value).toBe(1.5);
-      expect(after.items.a.x.value).toBe(-50);
+      expect(after.items.a.transform.scale.value).toBe(1.5);
+      expect(after.items.a.transform.x.value).toBe(-50);
     });
 
     it("converges carousel to snap target over many frames", () => {
@@ -489,15 +670,11 @@ describe("createCarouselReduce", () => {
       expect(after.type).toBe("scrolling");
     });
 
-    it("transitions to focused when a zoomed-in item is panned during snapping", () => {
+    it("ignores item-targeted motions during carousel snapping", () => {
       const reduce = makeReduce();
-      // Item a is at scale=1.5 > 1, so motion on it resolves to focused
-      const after = reduce(
-        makeSnappingState(),
-        motion({ itemId: "a", dx: 10 }),
-      );
-      expect(after.type).toBe("focused");
-      if (after.type === "focused") expect(after.focusedItemId).toBe("a");
+      const state = makeSnappingState();
+      const after = reduce(state, motion({ itemId: "a", dx: 10 }));
+      expect(after).toBe(state);
     });
   });
 

--- a/packages/core/src/model/carousel.ts
+++ b/packages/core/src/model/carousel.ts
@@ -9,6 +9,7 @@ import {
   advanceLinearInertia,
   advanceExponentialInertia,
   advanceLinearSpring,
+  advanceExponentialSpring,
 } from "./primitives.js";
 
 // ---------------------------------------------------------------------------
@@ -44,48 +45,53 @@ type ItemTransform = {
   scale: ExponentialPrimitive;
 };
 
+type ItemSnapTarget = { x: number; y: number; scale: number };
+
 /**
- * The phase is global: a single discriminant covers both the carousel strip and all items.
- * This keeps the state machine manageable — per-item phases would multiply the number of
- * possible state combinations exponentially.
+ * Per-item phase. Independent of the carousel-level phase.
  *
- * States:
- *   scrolling — carousel strip is being scrolled; items are not transformed.
- *   focused   — one specific item is receiving gesture input (pinch or pan while zoomed in).
- *   inertia   — the focused item is coasting after the gesture was released.
- *   snapping  — the carousel strip is spring-snapping to the nearest item boundary.
- *   settled   — everything is at rest.
+ *   settled  — at rest.
+ *   tracking — actively receiving gesture input (while carousel is locked).
+ *   inertia  — coasting after release.
+ *   snapping — spring-snapping back to a target (e.g. under-zoom recovery).
+ */
+export type ItemPrivateState =
+  | { type: "settled"; transform: ItemTransform }
+  | { type: "tracking"; transform: ItemTransform }
+  | { type: "inertia"; transform: ItemTransform }
+  | { type: "snapping"; transform: ItemTransform; target: ItemSnapTarget };
+
+/**
+ * Carousel-level phase. Tracks only the carousel strip's motion.
+ * Item-level concerns live in ItemPrivateState, one per item.
+ *
+ *   settled  — strip is at rest.
+ *   scrolling — user is dragging the strip.
+ *   snapping  — strip is spring-snapping to the nearest item boundary.
+ *   locked    — all motion is delegated to the active item (carousel entered
+ *               from settled; exits on release back to settled).
  */
 export type CarouselPrivateState =
   | {
+      type: "settled";
+      carousel: LinearPrimitive;
+      items: Record<string, ItemPrivateState>;
+    }
+  | {
       type: "scrolling";
       carousel: LinearPrimitive;
-      items: Record<string, ItemTransform>;
-    }
-  | {
-      type: "focused";
-      /** The item currently receiving gesture input. */
-      focusedItemId: string;
-      carousel: LinearPrimitive;
-      items: Record<string, ItemTransform>;
-    }
-  | {
-      type: "inertia";
-      /** The item coasting after the gesture was released. */
-      focusedItemId: string;
-      carousel: LinearPrimitive;
-      items: Record<string, ItemTransform>;
+      items: Record<string, ItemPrivateState>;
     }
   | {
       type: "snapping";
       carousel: LinearPrimitive;
       carouselTarget: number;
-      items: Record<string, ItemTransform>;
+      items: Record<string, ItemPrivateState>;
     }
   | {
-      type: "settled";
+      type: "locked";
       carousel: LinearPrimitive;
-      items: Record<string, ItemTransform>;
+      items: Record<string, ItemPrivateState>;
     };
 
 type MotionEvent = Extract<InterpreterEvent, { type: "motion" }>;
@@ -94,24 +100,25 @@ type MotionEvent = Extract<InterpreterEvent, { type: "motion" }>;
 // Constants
 // ---------------------------------------------------------------------------
 
-const SNAP_THRESHOLD = 0.5; // px
+const CAROUSEL_SNAP_THRESHOLD = 0.5; // px
+const ITEM_SNAP_THRESHOLD = 0.5; // px
+const ITEM_SCALE_SNAP_THRESHOLD = 0.001;
 const VELOCITY_THRESHOLD = 0.01; // px/ms
 const LOG_VELOCITY_THRESHOLD = 0.0001; // log-units/ms
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Item transform helpers
 // ---------------------------------------------------------------------------
 
 /**
  * Returns the pan bounds for an item at the given scale.
  * When scale <= 1 the item fits within its container, so there is no room to pan.
- * When scale > 1 the item extends beyond the container edges.
  *
  * Derivation (transform-origin at top-left):
  *   content occupies [transformX, transformX + itemWidth * scale]
  *   to keep content filling the viewport:
- *     transformX <= 0   (left edge at or before viewport left)
- *     transformX + itemWidth * scale >= itemWidth  →  transformX >= itemWidth * (1 - scale)
+ *     transformX <= 0
+ *     transformX >= itemWidth * (1 - scale)
  */
 function getItemBounds(
   scale: number,
@@ -127,22 +134,17 @@ function getItemBounds(
   };
 }
 
-/**
- * Applies a motion event to an item's transform, clamping translation to the item's
- * pan bounds. Overflow beyond the bounds is discarded.
- */
 function applyMotionToItem(
-  item: ItemTransform,
+  transform: ItemTransform,
   motion: MotionEvent,
   itemWidth: number,
   itemHeight: number,
 ): ItemTransform {
   const { dx, dy, dScale, originX, originY, timestamp } = motion;
-  const tx = item.x.value;
-  const ty = item.y.value;
-  const newScale = item.scale.value * dScale;
+  const tx = transform.x.value;
+  const ty = transform.y.value;
+  const newScale = transform.scale.value * dScale;
 
-  // Apply scale with origin (same formula as the single-item Model).
   const proposedTx = originX + (tx - originX) * dScale + dx;
   const proposedTy = originY + (ty - originY) * dScale + dy;
 
@@ -151,44 +153,235 @@ function applyMotionToItem(
   const clampedTy = Math.max(bounds.minY, Math.min(bounds.maxY, proposedTy));
 
   return {
-    x: applyLinearDelta(item.x, clampedTx - tx, timestamp),
-    y: applyLinearDelta(item.y, clampedTy - ty, timestamp),
-    scale: applyExponentialFactor(item.scale, dScale, timestamp),
+    x: applyLinearDelta(transform.x, clampedTx - tx, timestamp),
+    y: applyLinearDelta(transform.y, clampedTy - ty, timestamp),
+    scale: applyExponentialFactor(transform.scale, dScale, timestamp),
   };
 }
 
+function itemHasSignificantVelocity(transform: ItemTransform): boolean {
+  return (
+    Math.abs(transform.x.velocity) > VELOCITY_THRESHOLD ||
+    Math.abs(transform.y.velocity) > VELOCITY_THRESHOLD ||
+    Math.abs(transform.scale.logVelocity) > LOG_VELOCITY_THRESHOLD
+  );
+}
+
+function advanceItemInertia(
+  transform: ItemTransform,
+  timestamp: number,
+): ItemTransform {
+  return {
+    x: advanceLinearInertia(transform.x, timestamp),
+    y: advanceLinearInertia(transform.y, timestamp),
+    scale: advanceExponentialInertia(transform.scale, timestamp),
+  };
+}
+
+function advanceItemSpring(
+  transform: ItemTransform,
+  target: ItemSnapTarget,
+  timestamp: number,
+): ItemTransform {
+  return {
+    x: advanceLinearSpring(transform.x, target.x, timestamp),
+    y: advanceLinearSpring(transform.y, target.y, timestamp),
+    scale: advanceExponentialSpring(transform.scale, target.scale, timestamp),
+  };
+}
+
+function isItemSnapSettled(
+  transform: ItemTransform,
+  target: ItemSnapTarget,
+): boolean {
+  return (
+    Math.abs(transform.x.value - target.x) < ITEM_SNAP_THRESHOLD &&
+    Math.abs(transform.y.value - target.y) < ITEM_SNAP_THRESHOLD &&
+    Math.abs(transform.scale.value - target.scale) < ITEM_SCALE_SNAP_THRESHOLD
+  );
+}
+
+function settleItemTransform(transform: ItemTransform): ItemTransform {
+  return {
+    x: {
+      value: transform.x.value,
+      velocity: 0,
+      lastUpdatedAt: transform.x.lastUpdatedAt,
+    },
+    y: {
+      value: transform.y.value,
+      velocity: 0,
+      lastUpdatedAt: transform.y.lastUpdatedAt,
+    },
+    scale: {
+      value: transform.scale.value,
+      logVelocity: 0,
+      lastUpdatedAt: transform.scale.lastUpdatedAt,
+    },
+  };
+}
+
+function snapItemToTarget(
+  target: ItemSnapTarget,
+  timestamp: number,
+): ItemTransform {
+  return {
+    x: { value: target.x, velocity: 0, lastUpdatedAt: timestamp },
+    y: { value: target.y, velocity: 0, lastUpdatedAt: timestamp },
+    scale: { value: target.scale, logVelocity: 0, lastUpdatedAt: timestamp },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Item-level phase transitions
+// ---------------------------------------------------------------------------
+
+function releaseItem(
+  item: Extract<ItemPrivateState, { type: "tracking" }>,
+): ItemPrivateState {
+  if (item.transform.scale.value < 1) {
+    return {
+      type: "snapping",
+      transform: item.transform,
+      target: { x: 0, y: 0, scale: 1 },
+    };
+  }
+  if (itemHasSignificantVelocity(item.transform)) {
+    return { type: "inertia", transform: item.transform };
+  }
+  return { type: "settled", transform: settleItemTransform(item.transform) };
+}
+
+function advanceItem(
+  item: ItemPrivateState,
+  timestamp: number,
+): ItemPrivateState {
+  switch (item.type) {
+    case "settled":
+    case "tracking":
+      return item;
+    case "inertia": {
+      if (itemHasSignificantVelocity(item.transform)) {
+        return {
+          ...item,
+          transform: advanceItemInertia(item.transform, timestamp),
+        };
+      }
+      if (item.transform.scale.value < 1) {
+        return {
+          type: "snapping",
+          transform: item.transform,
+          target: { x: 0, y: 0, scale: 1 },
+        };
+      }
+      return {
+        type: "settled",
+        transform: settleItemTransform(item.transform),
+      };
+    }
+    case "snapping": {
+      if (isItemSnapSettled(item.transform, item.target)) {
+        return {
+          type: "settled",
+          transform: snapItemToTarget(item.target, timestamp),
+        };
+      }
+      return {
+        ...item,
+        transform: advanceItemSpring(item.transform, item.target, timestamp),
+      };
+    }
+  }
+}
+
+function advanceAllItems(
+  items: Record<string, ItemPrivateState>,
+  timestamp: number,
+): Record<string, ItemPrivateState> {
+  let changed = false;
+  const result: Record<string, ItemPrivateState> = {};
+  for (const [id, item] of Object.entries(items)) {
+    const next = advanceItem(item, timestamp);
+    result[id] = next;
+    if (next !== item) changed = true;
+  }
+  return changed ? result : items;
+}
+
+// ---------------------------------------------------------------------------
+// Routing helpers
+// ---------------------------------------------------------------------------
+
 /**
- * Determines whether a motion event should enter the "focused" state (item transform)
- * or the "scrolling" state (carousel scroll).
+ * Determines whether a motion event should lock the carousel to an item
+ * or scroll the carousel strip.
  *
- * Enters "focused" when the gesture targets an item that is already zoomed in,
- * or when the gesture itself includes a scale change (pinch).
+ * Locks when the target item is zoomed, in motion, or the gesture is a pinch.
  */
 function resolveMotionTarget(
   action: MotionEvent,
-  items: Record<string, ItemTransform>,
-): { type: "focused"; itemId: string } | { type: "scrolling" } {
+  items: Record<string, ItemPrivateState>,
+): { type: "locked"; itemId: string } | { type: "scrolling" } {
   if (action.itemId !== undefined) {
     const item = items[action.itemId];
-    if (item && (action.dScale !== 1 || item.scale.value > 1)) {
-      return { type: "focused", itemId: action.itemId };
+    if (item) {
+      const isZoomed = item.transform.scale.value !== 1;
+      const isInMotion = item.type !== "settled";
+      if (action.dScale !== 1 || isZoomed || isInMotion) {
+        return { type: "locked", itemId: action.itemId };
+      }
     }
   }
   return { type: "scrolling" };
 }
 
-function focusedItemHasSignificantVelocity(
-  items: Record<string, ItemTransform>,
-  focusedItemId: string,
-): boolean {
-  const item = items[focusedItemId];
-  if (!item) return false;
-  return (
-    Math.abs(item.x.velocity) > VELOCITY_THRESHOLD ||
-    Math.abs(item.y.velocity) > VELOCITY_THRESHOLD ||
-    Math.abs(item.scale.logVelocity) > LOG_VELOCITY_THRESHOLD
-  );
+function findTrackingItemId(
+  items: Record<string, ItemPrivateState>,
+): string | undefined {
+  for (const [id, item] of Object.entries(items)) {
+    if (item.type === "tracking") return id;
+  }
+  return undefined;
 }
+
+/**
+ * Transitions items into the locked state: starts tracking targetItemId and
+ * immediately settles any other items that are in motion (one active item at a time).
+ */
+function lockItems(
+  items: Record<string, ItemPrivateState>,
+  targetItemId: string,
+  action: MotionEvent,
+  itemWidth: number,
+  itemHeight: number,
+): Record<string, ItemPrivateState> {
+  const result: Record<string, ItemPrivateState> = {};
+  for (const [id, item] of Object.entries(items)) {
+    if (id === targetItemId) {
+      result[id] = {
+        type: "tracking",
+        transform: applyMotionToItem(
+          item.transform,
+          action,
+          itemWidth,
+          itemHeight,
+        ),
+      };
+    } else if (item.type !== "settled") {
+      result[id] = {
+        type: "settled",
+        transform: settleItemTransform(item.transform),
+      };
+    } else {
+      result[id] = item;
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Carousel-level helpers
+// ---------------------------------------------------------------------------
 
 function computeCarouselSnapTarget(
   x: number,
@@ -196,50 +389,11 @@ function computeCarouselSnapTarget(
   itemCount: number,
 ): number {
   const nearest = Math.round(x / itemWidth) * itemWidth;
-  // Clamp to valid range: [-(itemCount - 1) * itemWidth, 0]
   return Math.max(-(itemCount - 1) * itemWidth, Math.min(0, nearest));
 }
 
 function isCarouselSettled(carousel: LinearPrimitive, target: number): boolean {
-  return Math.abs(carousel.value - target) < SNAP_THRESHOLD;
-}
-
-function advanceFocusedItemInertia(
-  items: Record<string, ItemTransform>,
-  focusedItemId: string,
-  timestamp: number,
-): Record<string, ItemTransform> {
-  const item = items[focusedItemId];
-  if (!item) return items;
-  return {
-    ...items,
-    [focusedItemId]: {
-      x: advanceLinearInertia(item.x, timestamp),
-      y: advanceLinearInertia(item.y, timestamp),
-      scale: advanceExponentialInertia(item.scale, timestamp),
-    },
-  };
-}
-
-function settleFocusedItem(
-  items: Record<string, ItemTransform>,
-  focusedItemId: string,
-  timestamp: number,
-): Record<string, ItemTransform> {
-  const item = items[focusedItemId];
-  if (!item) return items;
-  return {
-    ...items,
-    [focusedItemId]: {
-      x: { value: item.x.value, velocity: 0, lastUpdatedAt: timestamp },
-      y: { value: item.y.value, velocity: 0, lastUpdatedAt: timestamp },
-      scale: {
-        value: item.scale.value,
-        logVelocity: 0,
-        lastUpdatedAt: timestamp,
-      },
-    },
-  };
+  return Math.abs(carousel.value - target) < CAROUSEL_SNAP_THRESHOLD;
 }
 
 // ---------------------------------------------------------------------------
@@ -255,9 +409,9 @@ export function toCarouselPublicState(
   > = {};
   for (const [id, item] of Object.entries(state.items)) {
     items[id] = {
-      transformX: item.x.value,
-      transformY: item.y.value,
-      scale: item.scale.value,
+      transformX: item.transform.x.value,
+      transformY: item.transform.y.value,
+      scale: item.transform.scale.value,
     };
   }
   return { carouselTranslateX: state.carousel.value, items };
@@ -268,69 +422,19 @@ export function createCarouselReduce(
 ): Reducer<CarouselPrivateState> {
   const { itemWidth, itemHeight, itemIds } = config;
 
-  function makeInitialItems(): Record<string, ItemTransform> {
-    const items: Record<string, ItemTransform> = {};
+  function makeInitialItems(): Record<string, ItemPrivateState> {
+    const items: Record<string, ItemPrivateState> = {};
     for (const id of itemIds) {
       items[id] = {
-        x: createLinearPrimitive(0),
-        y: createLinearPrimitive(0),
-        scale: createExponentialPrimitive(1),
+        type: "settled",
+        transform: {
+          x: createLinearPrimitive(0),
+          y: createLinearPrimitive(0),
+          scale: createExponentialPrimitive(1),
+        },
       };
     }
     return items;
-  }
-
-  function applyScrollingMotion(
-    carousel: LinearPrimitive,
-    action: MotionEvent,
-  ): LinearPrimitive {
-    return applyLinearDelta(carousel, action.dx, action.timestamp);
-  }
-
-  /**
-   * Applies a motion event to the focused item only. Returns null when the event
-   * does not target the focused item (caller should treat this as a no-op).
-   */
-  function applyFocusedMotion(
-    items: Record<string, ItemTransform>,
-    focusedItemId: string,
-    action: MotionEvent,
-  ): Record<string, ItemTransform> | null {
-    if (action.itemId !== focusedItemId) return null;
-    const item = items[focusedItemId];
-    if (!item) return null;
-    return {
-      ...items,
-      [focusedItemId]: applyMotionToItem(item, action, itemWidth, itemHeight),
-    };
-  }
-
-  /**
-   * Handles a motion event from any state that can freely transition to either
-   * "scrolling" or "focused". Applies the motion and returns the resulting state.
-   */
-  function applyMotionFromAnyState(
-    carousel: LinearPrimitive,
-    items: Record<string, ItemTransform>,
-    action: MotionEvent,
-  ): CarouselPrivateState {
-    const target = resolveMotionTarget(action, items);
-    if (target.type === "focused") {
-      const newItems = applyFocusedMotion(items, target.itemId, action);
-      if (newItems) {
-        return {
-          type: "focused",
-          focusedItemId: target.itemId,
-          carousel,
-          items: newItems,
-        };
-      }
-    }
-    return {
-      type: "scrolling",
-      carousel: applyScrollingMotion(carousel, action),
-      items,
-    };
   }
 
   return function reduce(
@@ -342,30 +446,54 @@ export function createCarouselReduce(
     action: StoreAction,
   ): CarouselPrivateState {
     switch (state.type) {
-      case "scrolling": {
+      case "settled": {
         switch (action.type) {
           case "motion": {
             const target = resolveMotionTarget(action, state.items);
-            if (target.type === "focused") {
-              const newItems = applyFocusedMotion(
-                state.items,
-                target.itemId,
-                action,
-              );
-              if (newItems) {
-                return {
-                  type: "focused",
-                  focusedItemId: target.itemId,
-                  carousel: state.carousel,
-                  items: newItems,
-                };
-              }
+            if (target.type === "locked") {
+              return {
+                type: "locked",
+                carousel: state.carousel,
+                items: lockItems(
+                  state.items,
+                  target.itemId,
+                  action,
+                  itemWidth,
+                  itemHeight,
+                ),
+              };
             }
             return {
-              ...state,
-              carousel: applyScrollingMotion(state.carousel, action),
+              type: "scrolling",
+              carousel: applyLinearDelta(
+                state.carousel,
+                action.dx,
+                action.timestamp,
+              ),
+              items: state.items,
             };
           }
+          case "release":
+            return state;
+          case "tick": {
+            const items = advanceAllItems(state.items, action.timestamp);
+            return items === state.items ? state : { ...state, items };
+          }
+        }
+        throw new Error("unreachable");
+      }
+
+      case "scrolling": {
+        switch (action.type) {
+          case "motion":
+            return {
+              ...state,
+              carousel: applyLinearDelta(
+                state.carousel,
+                action.dx,
+                action.timestamp,
+              ),
+            };
           case "release": {
             const carouselTarget = computeCarouselSnapTarget(
               state.carousel.value,
@@ -379,78 +507,35 @@ export function createCarouselReduce(
               items: state.items,
             };
           }
-          case "tick":
-            return state;
-        }
-        throw new Error("unreachable");
-      }
-      case "focused": {
-        switch (action.type) {
-          case "motion": {
-            // Only handle motion targeting the focused item; ignore everything else.
-            const newItems = applyFocusedMotion(
-              state.items,
-              state.focusedItemId,
-              action,
-            );
-            if (!newItems) return state;
-            return { ...state, items: newItems };
-          }
-          case "release":
-            return {
-              type: "inertia",
-              focusedItemId: state.focusedItemId,
-              carousel: state.carousel,
-              items: state.items,
-            };
-          case "tick":
-            return state;
-        }
-        throw new Error("unreachable");
-      }
-      case "inertia": {
-        switch (action.type) {
-          case "motion":
-            return applyMotionFromAnyState(state.carousel, state.items, action);
-          case "release":
-            return state;
           case "tick": {
-            if (
-              focusedItemHasSignificantVelocity(
-                state.items,
-                state.focusedItemId,
-              )
-            ) {
-              return {
-                ...state,
-                items: advanceFocusedItemInertia(
-                  state.items,
-                  state.focusedItemId,
-                  action.timestamp,
-                ),
-              };
-            }
-            return {
-              type: "settled",
-              carousel: state.carousel,
-              items: settleFocusedItem(
-                state.items,
-                state.focusedItemId,
-                action.timestamp,
-              ),
-            };
+            const items = advanceAllItems(state.items, action.timestamp);
+            return items === state.items ? state : { ...state, items };
           }
         }
         throw new Error("unreachable");
       }
+
       case "snapping": {
         switch (action.type) {
-          case "motion":
-            return applyMotionFromAnyState(state.carousel, state.items, action);
+          case "motion": {
+            // Allow the user to interrupt a snap by scrolling (no itemId), but
+            // ignore item-targeted motions since locked can only be entered from settled.
+            if (action.itemId !== undefined) return state;
+            return {
+              type: "scrolling",
+              carousel: applyLinearDelta(
+                state.carousel,
+                action.dx,
+                action.timestamp,
+              ),
+              items: state.items,
+            };
+          }
           case "release":
             return state;
           case "tick": {
             const { carouselTarget } = state;
+            const items = advanceAllItems(state.items, action.timestamp);
             if (isCarouselSettled(state.carousel, carouselTarget)) {
               return {
                 type: "settled",
@@ -459,7 +544,7 @@ export function createCarouselReduce(
                   velocity: 0,
                   lastUpdatedAt: action.timestamp,
                 },
-                items: state.items,
+                items,
               };
             }
             return {
@@ -469,19 +554,62 @@ export function createCarouselReduce(
                 carouselTarget,
                 action.timestamp,
               ),
+              items,
             };
           }
         }
         throw new Error("unreachable");
       }
-      case "settled": {
+
+      case "locked": {
         switch (action.type) {
-          case "motion":
-            return applyMotionFromAnyState(state.carousel, state.items, action);
-          case "release":
-            return state;
-          case "tick":
-            return state;
+          case "motion": {
+            const trackingId = findTrackingItemId(state.items);
+            if (trackingId === undefined || action.itemId !== trackingId)
+              return state;
+            const item = state.items[trackingId] as Extract<
+              ItemPrivateState,
+              { type: "tracking" }
+            >;
+            return {
+              ...state,
+              items: {
+                ...state.items,
+                [trackingId]: {
+                  type: "tracking",
+                  transform: applyMotionToItem(
+                    item.transform,
+                    action,
+                    itemWidth,
+                    itemHeight,
+                  ),
+                },
+              },
+            };
+          }
+          case "release": {
+            const trackingId = findTrackingItemId(state.items);
+            if (trackingId === undefined) {
+              return {
+                type: "settled",
+                carousel: state.carousel,
+                items: state.items,
+              };
+            }
+            const item = state.items[trackingId] as Extract<
+              ItemPrivateState,
+              { type: "tracking" }
+            >;
+            return {
+              type: "settled",
+              carousel: state.carousel,
+              items: { ...state.items, [trackingId]: releaseItem(item) },
+            };
+          }
+          case "tick": {
+            const items = advanceAllItems(state.items, action.timestamp);
+            return items === state.items ? state : { ...state, items };
+          }
         }
         throw new Error("unreachable");
       }


### PR DESCRIPTION
## Summary

- Replace the single global phase with independent **carousel-level phase** (`settled | scrolling | snapping | locked`) and **per-item phase** (`settled | tracking | inertia | snapping`)
- Remove `focusedItemId` — the active item is identified by scanning for the item in `tracking` state
- Add `locked` carousel phase: entered from `settled` when a gesture targets an item; exits on `release` back to `settled`; motions without `itemId` are ignored while locked
- Items animate independently of the carousel phase (parallel operation): an item can coast in `inertia` while the carousel scrolls or snaps
- Add item-level `snapping` for under-zoom recovery: when scale < 1 on release, the item springs back to `{ x: 0, y: 0, scale: 1 }`

Design decisions documented in #7.

## Test plan

- [ ] `npm run tsc && npm run format && npm run lint && npm run test` all pass
- [ ] Carousel scrolling behavior unchanged
- [ ] Item pinch/pan (zoomed item) transitions through `locked → tracking → inertia → settled`
- [ ] Releasing a pinched item while under-zoomed triggers `snapping` → springs back to scale=1
- [ ] Starting carousel scroll while item is in `inertia` works without interrupting item animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)