### PR TITLE
Handle overscroll on zoomed items

### DIFF
--- a/packages/core/src/interpreter/__tests__/mouse-wheel.test.ts
+++ b/packages/core/src/interpreter/__tests__/mouse-wheel.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { InterpreterEvent } from "../../types.js";
 import { mouseWheelInterpreter } from "../mouse-wheel.js";
 
 describe("mouseWheelInterpreter", () => {
@@ -26,8 +27,8 @@ describe("mouseWheelInterpreter", () => {
 
   it("emits zoom-in motion on negative deltaY", () => {
     const interpreter = mouseWheelInterpreter()(element);
-    const motions: { dScale: number }[] = [];
-    interpreter.subscribe((m) => motions.push(m as { dScale: number }));
+    const motions: InterpreterEvent[] = [];
+    interpreter.subscribe((m) => motions.push(m));
 
     element.dispatchEvent(
       new WheelEvent("wheel", {
@@ -38,16 +39,24 @@ describe("mouseWheelInterpreter", () => {
       }),
     );
 
-    expect(motions).toHaveLength(1);
-    expect(motions[0].dScale).toBeGreaterThan(1); // scrolling up = zoom in
+    expect(motions).toHaveLength(3);
+    expect(motions[0].type).toBe("motion");
+    if (motions[0].type === "motion") {
+      expect(motions[0].dScale).toBeGreaterThan(1); // scrolling up = zoom in
+    }
+    expect(motions[1].type).toBe("motion");
+    if (motions[1].type === "motion") {
+      expect(motions[1].dScale).toEqual(1); // scrolling up = zoom in
+    }
+    expect(motions[2].type).toBe("release");
 
     interpreter.unmount();
   });
 
   it("emits zoom-out motion on positive deltaY", () => {
     const interpreter = mouseWheelInterpreter()(element);
-    const motions: { dScale: number }[] = [];
-    interpreter.subscribe((m) => motions.push(m as { dScale: number }));
+    const motions: InterpreterEvent[] = [];
+    interpreter.subscribe((m) => motions.push(m as InterpreterEvent));
 
     element.dispatchEvent(
       new WheelEvent("wheel", {
@@ -58,9 +67,11 @@ describe("mouseWheelInterpreter", () => {
       }),
     );
 
-    expect(motions).toHaveLength(1);
-    expect(motions[0].dScale).toBeLessThan(1); // scrolling down = zoom out
-
+    expect(motions).toHaveLength(3);
+    expect(motions[0].type).toBe("motion");
+    if (motions[0].type === "motion") {
+      expect(motions[0].dScale).toBeLessThan(1); // scrolling down = zoom out
+    }
     interpreter.unmount();
   });
 

--- a/packages/core/src/interpreter/mouse-wheel.ts
+++ b/packages/core/src/interpreter/mouse-wheel.ts
@@ -46,6 +46,18 @@ export function mouseWheelInterpreter(): Interpreter {
         originX,
         originY,
       });
+      emit({
+        type: "motion",
+        timestamp: e.timeStamp,
+        dx: 0,
+        dy: 0,
+        dScale: 1,
+        originX,
+        originY,
+      });
+      emit({
+        type: "release",
+      });
     }
 
     element.addEventListener("wheel", onWheel as EventListener, {

--- a/packages/core/src/model/__tests__/carousel.test.ts
+++ b/packages/core/src/model/__tests__/carousel.test.ts
@@ -185,21 +185,6 @@ describe("createCarouselModel", () => {
       expect(reduce(state, { type: "release" })).toBe(state);
     });
 
-    it("transitions to indeterminate on motion (no itemId)", () => {
-      const reduce = makeReduce();
-      const state = reduce(free(), motion({ dx: -50 }));
-      expect(state.type).toBe("indeterminate");
-      expect(state.carousel.type).toBe("settled");
-    });
-
-    it("transitions to indeterminate on motion (with itemId)", () => {
-      const reduce = makeReduce();
-      const state = reduce(free(), motion({ itemId: "a", dx: -50 }));
-      expect(state.type).toBe("indeterminate");
-      expect(state.carousel.type).toBe("settled");
-      expect(state.items.a.x.value).toBe(0);
-    });
-
     it("advances inertia items on tick (parallel operation)", () => {
       const reduce = makeReduce();
       const state: CarouselPrivateState = {
@@ -216,43 +201,10 @@ describe("createCarouselModel", () => {
       expect(next.items.a.type).toBe("inertia");
       expect(next.items.a.x.value).toBeLessThan(-50);
     });
-  });
-
-  // -------------------------------------------------------------------------
-  // indeterminate state
-  // -------------------------------------------------------------------------
-
-  describe("indeterminate state", () => {
-    it("returns to free on release", () => {
-      const reduce = makeReduce();
-      const indeterminate = reduce(free(), motion());
-      expect(indeterminate.type).toBe("indeterminate");
-      const next = reduce(indeterminate, { type: "release" });
-      expect(next.type).toBe("free");
-      expect(next.carousel.type).toBe("settled");
-    });
-
-    it("advances animations on tick", () => {
-      const reduce = makeReduce();
-      const state: CarouselPrivateState = {
-        type: "indeterminate",
-        carousel: makeSettledCarousel(),
-        items: {
-          a: makeInertiaItem(-50, 0, 2, -5),
-          b: makeSettledItem(),
-          c: makeSettledItem(),
-        },
-      };
-      const next = reduce(state, { type: "tick", timestamp: 16 });
-      expect(next.type).toBe("indeterminate");
-      expect(next.items.a.type).toBe("inertia");
-      expect(next.items.a.x.value).toBeLessThan(-50);
-    });
 
     it("transitions to carousel on carousel pan (no itemId)", () => {
       const reduce = makeReduce();
-      let state = reduce(free(), motion({ dx: -50 }));
-      state = reduce(state, motion({ dx: -50 }));
+      const state = reduce(free(), motion({ dx: -50 }));
       expect(state.type).toBe("carousel");
       expect(state.carousel.type).toBe("tracking");
       // First tracking update establishes origin; position unchanged
@@ -261,8 +213,7 @@ describe("createCarouselModel", () => {
 
     it("transitions to carousel when item at scale=1 is panned (carousel moves, item stays)", () => {
       const reduce = makeReduce();
-      let state = reduce(free(), motion({ itemId: "a", dx: -80 }));
-      state = reduce(state, motion({ itemId: "a", dx: -80 }));
+      const state = reduce(free(), motion({ itemId: "a", dx: -80 }));
       expect(state.type).toBe("carousel");
       expect(state.carousel.type).toBe("tracking");
       expect(state.carousel.x.value).toBeCloseTo(0);
@@ -288,8 +239,7 @@ describe("createCarouselModel", () => {
 
     it("transitions to items on pinch (dScale != 1), even when item is at scale=1", () => {
       const reduce = makeReduce();
-      let state = reduce(free(), motion({ itemId: "a" }));
-      state = reduce(state, motion({ itemId: "a", dScale: 1.5 }));
+      const state = reduce(free(), motion({ itemId: "a", dScale: 1.5 }));
       expect(state.type).toBe("items");
       if (state.type === "items") {
         expect(state.activeItemId).toBe("a");
@@ -446,8 +396,7 @@ describe("createCarouselModel", () => {
           c: makeSettledItem(),
         },
       };
-      let state = reduce(freeWithInertia, motion({ dx: -30 })); // → indeterminate
-      state = reduce(state, motion({ dx: -30 })); // → carousel, tracking
+      const state = reduce(freeWithInertia, motion({ dx: -30 })); // → carousel, tracking
       expect(state.type).toBe("carousel");
       expect(state.carousel.type).toBe("tracking");
       expect(state.items.a.type).toBe("inertia"); // item continues
@@ -806,9 +755,7 @@ describe("createCarouselModel", () => {
     it("transitions to carousel tracking on motion without itemId (interrupts snap)", () => {
       const reduce = makeReduce();
       let state: CarouselPrivateState = makeSnappingState();
-      state = reduce(state, motion({ dx: -20 })); // → indeterminate
-      expect(state.type).toBe("indeterminate");
-      state = reduce(state, motion({ dx: -20 })); // → carousel (snap interrupted)
+      state = reduce(state, motion({ dx: -20 })); // → carousel
       expect(state.type).toBe("carousel");
       expect(state.carousel.type).toBe("tracking");
     });

--- a/packages/core/src/model/__tests__/carousel.test.ts
+++ b/packages/core/src/model/__tests__/carousel.test.ts
@@ -207,8 +207,7 @@ describe("createCarouselModel", () => {
       const state = reduce(free(), motion({ dx: -50 }));
       expect(state.type).toBe("carousel");
       expect(state.carousel.type).toBe("tracking");
-      // First tracking update establishes origin; position unchanged
-      expect(state.carousel.x.value).toBeCloseTo(0);
+      expect(state.carousel.x.value).toBeCloseTo(-50);
     });
 
     it("transitions to carousel when item at scale=1 is panned (carousel moves, item stays)", () => {
@@ -216,7 +215,7 @@ describe("createCarouselModel", () => {
       const state = reduce(free(), motion({ itemId: "a", dx: -80 }));
       expect(state.type).toBe("carousel");
       expect(state.carousel.type).toBe("tracking");
-      expect(state.carousel.x.value).toBeCloseTo(0);
+      expect(state.carousel.x.value).toBeCloseTo(-80);
       expect(state.items.a.x.value).toBe(0);
     });
 

--- a/packages/core/src/model/__tests__/carousel.test.ts
+++ b/packages/core/src/model/__tests__/carousel.test.ts
@@ -219,6 +219,40 @@ describe("createCarouselModel", () => {
       expect(state.items.a.x.value).toBe(0);
     });
 
+    it("transitions to carousel when zoomed item overscrolls right (at right edge, dx > 0)", () => {
+      const reduce = makeReduce();
+      // item a: zoomed to scale=2, x=0 (right edge, maxX=0)
+      const state = reduce(
+        free(0, { a: { x: 0, y: 0, scale: 2 } }),
+        motion({ itemId: "a", dx: 50 }),
+      );
+      expect(state.type).toBe("carousel");
+      expect(state.carousel.type).toBe("tracking");
+      expect(state.carousel.x.value).toBeCloseTo(50);
+    });
+
+    it("transitions to carousel when zoomed item overscrolls left (at left edge, dx < 0)", () => {
+      const reduce = makeReduce();
+      // item a: zoomed to scale=2, x=minX=-400 (left edge)
+      const state = reduce(
+        free(0, { a: { x: -ITEM_WIDTH, y: 0, scale: 2 } }),
+        motion({ itemId: "a", dx: -50 }),
+      );
+      expect(state.type).toBe("carousel");
+      expect(state.carousel.type).toBe("tracking");
+      expect(state.carousel.x.value).toBeCloseTo(-50);
+    });
+
+    it("does not transition to carousel when zoomed item is panned within bounds", () => {
+      const reduce = makeReduce();
+      // item a: zoomed to scale=2, x=-200 (middle, minX=-400, maxX=0)
+      const state = reduce(
+        free(0, { a: { x: -200, y: 0, scale: 2 } }),
+        motion({ itemId: "a", dx: -50 }),
+      );
+      expect(state.type).toBe("items");
+    });
+
     it("transitions to items when a zoomed-in item is panned", () => {
       const reduce = makeReduce();
       let state = reduce(
@@ -332,7 +366,7 @@ describe("createCarouselModel", () => {
     it("snap target stays at 0 when swiped less than halfway to next item", () => {
       const reduce = makeReduce();
       let state = reduce(free(), motion());
-      state = reduce(state, motion({ dx: -190 })); // first tracking motion: origin at 0, dx ignored
+      state = reduce(state, motion({ dx: -190 })); // → x = -190, still snaps to 0 (< halfway to next item)
       state = reduce(state, { type: "release" });
       if (state.carousel.type === "snapping") {
         expect(state.carousel.target.x).toBeCloseTo(0);

--- a/packages/core/src/model/carousel.ts
+++ b/packages/core/src/model/carousel.ts
@@ -40,8 +40,6 @@ export type CarouselPublicState = {
  * Carousel-level phase.
  *
  *   free          — no active gesture; animations may still be running.
- *   indeterminate — entered on the first motion from free; the next motion
- *                   determines whether to scroll the carousel or pan/zoom an item.
  *   carousel      — gesture is scrolling the carousel strip.
  *   items         — gesture is targeting activeItemId for pan/zoom.
  *
@@ -50,11 +48,6 @@ export type CarouselPublicState = {
 export type CarouselPrivateState =
   | {
       type: "free";
-      carousel: TransformPrivateState;
-      items: Record<string, TransformPrivateState>;
-    }
-  | {
-      type: "indeterminate";
       carousel: TransformPrivateState;
       items: Record<string, TransformPrivateState>;
     }
@@ -222,23 +215,6 @@ function createCarouselReduce(config: CarouselConfig) {
     switch (state.type) {
       case "free": {
         switch (action.type) {
-          case "motion":
-            return { ...state, type: "indeterminate" };
-          case "release":
-            return state;
-          case "tick": {
-            const carousel = carouselReduce(state.carousel, action);
-            const items = advanceAllItems(state.items, action.timestamp);
-            if (carousel === state.carousel && items === state.items)
-              return state;
-            return { ...state, carousel, items };
-          }
-        }
-        throw new Error("unreachable");
-      }
-
-      case "indeterminate": {
-        switch (action.type) {
           case "motion": {
             // Determine whether a motion event should lock the carousel to an item
             // or scroll the carousel strip.
@@ -271,11 +247,7 @@ function createCarouselReduce(config: CarouselConfig) {
             return { type: "carousel", carousel, items: state.items };
           }
           case "release":
-            return {
-              type: "free",
-              carousel: state.carousel,
-              items: state.items,
-            };
+            return state;
           case "tick": {
             const carousel = carouselReduce(state.carousel, action);
             const items = advanceAllItems(state.items, action.timestamp);

--- a/packages/core/src/model/carousel.ts
+++ b/packages/core/src/model/carousel.ts
@@ -93,6 +93,19 @@ function getItemBounds(
   };
 }
 
+function isHorizontalOverscroll(
+  item: TransformPrivateState,
+  dx: number,
+  itemWidth: number,
+  itemHeight: number,
+): boolean {
+  const bounds = getItemBounds(item.scale.value, itemWidth, itemHeight);
+  return (
+    (dx > 0 && item.x.value >= bounds.maxX) ||
+    (dx < 0 && item.x.value <= bounds.minX)
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Carousel-level helpers
 // ---------------------------------------------------------------------------
@@ -225,13 +238,25 @@ function createCarouselReduce(config: CarouselConfig) {
                   const isZoomed = item.scale.value !== 1;
                   const isInMotion = item.type !== "settled";
                   if (action.dScale !== 1 || isZoomed || isInMotion) {
-                    // Lock to item
-                    return {
-                      type: "items",
-                      carousel: state.carousel,
-                      items: lockItems(state.items, action.itemId, action),
-                      activeItemId: action.itemId,
-                    };
+                    const overscroll =
+                      isZoomed &&
+                      !isInMotion &&
+                      action.dScale === 1 &&
+                      isHorizontalOverscroll(
+                        item,
+                        action.dx,
+                        itemWidth,
+                        itemHeight,
+                      );
+                    if (!overscroll) {
+                      // Lock to item
+                      return {
+                        type: "items",
+                        carousel: state.carousel,
+                        items: lockItems(state.items, action.itemId, action),
+                        activeItemId: action.itemId,
+                      };
+                    }
                   }
                 }
               }

--- a/packages/core/src/model/transform.ts
+++ b/packages/core/src/model/transform.ts
@@ -277,13 +277,17 @@ export function createTransformReduce(config?: TransformConfig) {
       case "settled": {
         switch (action.type) {
           case "motion":
-            return {
-              type: "tracking",
-              origin: { x: 0, y: 0 },
-              x: state.x,
-              y: state.y,
-              scale: state.scale,
-            };
+            // Transition to tracking then immediately apply the delta.
+            return reduce(
+              {
+                type: "tracking",
+                origin: { x: 0, y: 0 },
+                x: state.x,
+                y: state.y,
+                scale: state.scale,
+              },
+              action,
+            );
           case "release":
             return state;
           case "tick":


### PR DESCRIPTION
CLAUDE:

## Summary

- ズームされたアイテムを水平バウンズの端までパンしてジェスチャーを継続すると、`items` 状態にとどまらずカルーセルへ遷移するようになった
- `transform` reducer が最初のモーションイベントからデルタを即時適用するよう変更したことに伴い、既存テストのアサーションを修正
- マウスホイール操作でリリースイベントが確実に発行されるよう修正

## Changes

- `carousel.ts`: `isHorizontalOverscroll()` ヘルパーを追加し、`free` 状態の `motion` ハンドラでオーバースクロール検出時にカルーセルへ遷移
- `transform.ts`: settled 状態からの最初のモーションでデルタを即時適用
- `mouse-wheel.ts`: リリースイベントの確実な発行
- テスト追加・修正