### PR TITLE
Add double-tap zoom toggle

### DIFF
--- a/design/00_architecture.md
+++ b/design/00_architecture.md
@@ -46,12 +46,13 @@ type Motion = {
 };
 ```
 
-**InterpreterEvent** is the output of an Interpreter. It is a tagged union that covers both gesture movement and the moment the user releases the gesture.
+**InterpreterEvent** is the output of an Interpreter. It is a tagged union that covers gesture movement, the moment the user releases the gesture, and discrete tap gestures.
 
 ```typescript
 type InterpreterEvent =
-  | ({ type: 'motion'; itemId?: string; timestamp: number } & Motion) // user is actively gesturing
-  | { type: 'release'; itemId?: string };                             // user lifted all fingers / released the mouse button
+  | ({ type: 'motion'; itemId?: string; timestamp: number } & Motion)                                        // user is actively gesturing
+  | { type: 'release'; itemId?: string }                                                                      // user lifted all fingers / released the mouse button
+  | { type: 'toggle-zoom'; itemId?: string; originX: number; originY: number; timestamp: number };           // double-tap: zoom in if at normal scale, zoom out otherwise
 ```
 
 The optional `itemId` field identifies which item within a multi-item container (e.g. a carousel) the gesture targets. It is absent for container-level gestures such as swiping the carousel strip itself.
@@ -116,6 +117,7 @@ type MountedInterpreter = {
 declare function touchInterpreter(): Interpreter;
 declare function mouseDragInterpreter(): Interpreter;
 declare function mouseWheelInterpreter(): Interpreter;
+declare function doubleTapInterpreter(): Interpreter;
 ```
 
 Implementation details:
@@ -124,6 +126,7 @@ Implementation details:
 - **touchInterpreter**: A factory function for an interpreter that handles touch events. Tracks multiple touch points and identifies gestures such as pinch and pan.
 - **mouseDragInterpreter**: A factory function for an interpreter that handles mouse drag events. Tracks mouse movement and identifies pan gestures.
 - **mouseWheelInterpreter**: A factory function for an interpreter that handles mouse wheel events. Tracks wheel rotation and identifies zoom gestures.
+- **doubleTapInterpreter**: A factory function for an interpreter that detects double-tap gestures. Handles the native `dblclick` event for mouse and manually tracks two consecutive single-finger touches within a time and distance threshold for touch. Emits `toggle-zoom`.
 
 ### State Representation
 
@@ -131,6 +134,7 @@ Each stateful interpreter models its internal state as a tagged union following 
 
 - `touchInterpreter`: `no_touch | single_touch | multi_touch`
 - `mouseDragInterpreter`: `idle | dragging`
+- `doubleTapInterpreter`: `idle | awaiting_second_tap`
 
 For example, a `single_touch` state necessarily carries exactly one touch point, and a `multi_touch` state necessarily carries exactly two. `touchInterpreter` can transition `no_touch → single_touch` and `single_touch → multi_touch`, but not `no_touch → multi_touch` directly.
 

--- a/design/01_technology_stack.md
+++ b/design/01_technology_stack.md
@@ -19,6 +19,7 @@ packages/
         touch.ts
         mouse-drag.ts
         mouse-wheel.ts
+        double-tap.ts
         index.ts
       store/
         primitives.ts    # LinearPrimitive, ExponentialPrimitive

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export {
   touchInterpreter,
   mouseDragInterpreter,
   mouseWheelInterpreter,
+  doubleTapInterpreter,
 } from "./interpreter/index.js";
 export { createStore } from "./store/index.js";
 export { createRenderer } from "./renderer/index.js";

--- a/packages/core/src/interpreter/__tests__/double-tap.test.ts
+++ b/packages/core/src/interpreter/__tests__/double-tap.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { InterpreterEvent } from "../../types.js";
+import { doubleTapInterpreter } from "../double-tap.js";
+
+function makeTouch(id: number, x: number, y: number): Touch {
+  return {
+    identifier: id,
+    clientX: x,
+    clientY: y,
+    pageX: x,
+    pageY: y,
+    screenX: x,
+    screenY: y,
+    target: document.body,
+    radiusX: 1,
+    radiusY: 1,
+    rotationAngle: 0,
+    force: 1,
+    altitudeAngle: 0,
+    azimuthAngle: 0,
+    touchType: "direct",
+  } as unknown as Touch;
+}
+
+/** touchstart with the given active touches */
+function makeTouchStartEvent(touches: Touch[]): TouchEvent {
+  return new TouchEvent("touchstart", {
+    touches,
+    changedTouches: touches,
+    bubbles: true,
+    cancelable: true,
+  });
+}
+
+/** touchend where `ended` was lifted and no touches remain */
+function makeTouchEndEvent(ended: Touch): TouchEvent {
+  return new TouchEvent("touchend", {
+    touches: [],
+    changedTouches: [ended],
+    bubbles: true,
+    cancelable: true,
+  });
+}
+
+describe("doubleTapInterpreter", () => {
+  let element: HTMLElement;
+
+  beforeEach(() => {
+    element = document.createElement("div");
+    vi.spyOn(element, "getBoundingClientRect").mockReturnValue({
+      left: 0,
+      top: 0,
+      right: 200,
+      bottom: 200,
+      width: 200,
+      height: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(element);
+  });
+
+  // -------------------------------------------------------------------------
+  // Mouse (dblclick)
+  // -------------------------------------------------------------------------
+
+  it("emits toggle-zoom on dblclick", () => {
+    const interpreter = doubleTapInterpreter()(element);
+    const events: InterpreterEvent[] = [];
+    interpreter.subscribe((e) => events.push(e));
+
+    element.dispatchEvent(
+      new MouseEvent("dblclick", { clientX: 100, clientY: 80, bubbles: true }),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("toggle-zoom");
+    interpreter.unmount();
+  });
+
+  it("sets dblclick origin relative to element top-left", () => {
+    vi.spyOn(element, "getBoundingClientRect").mockReturnValue({
+      left: 50,
+      top: 30,
+      right: 250,
+      bottom: 230,
+      width: 200,
+      height: 200,
+      x: 50,
+      y: 30,
+      toJSON: () => {},
+    });
+
+    const interpreter = doubleTapInterpreter()(element);
+    const events: InterpreterEvent[] = [];
+    interpreter.subscribe((e) => events.push(e));
+
+    element.dispatchEvent(
+      new MouseEvent("dblclick", { clientX: 150, clientY: 130, bubbles: true }),
+    );
+
+    expect(events[0].type).toBe("toggle-zoom");
+    if (events[0].type === "toggle-zoom") {
+      expect(events[0].originX).toBe(100); // 150 - 50
+      expect(events[0].originY).toBe(100); // 130 - 30
+    }
+    interpreter.unmount();
+  });
+
+  // -------------------------------------------------------------------------
+  // Touch
+  // -------------------------------------------------------------------------
+
+  it("does not emit on a single tap", () => {
+    const interpreter = doubleTapInterpreter()(element);
+    const events: InterpreterEvent[] = [];
+    interpreter.subscribe((e) => events.push(e));
+
+    const touch = makeTouch(0, 100, 100);
+    element.dispatchEvent(makeTouchStartEvent([touch]));
+    element.dispatchEvent(makeTouchEndEvent(touch));
+
+    expect(events).toHaveLength(0);
+    interpreter.unmount();
+  });
+
+  it("emits toggle-zoom on touch double-tap at same location", () => {
+    const interpreter = doubleTapInterpreter()(element);
+    const events: InterpreterEvent[] = [];
+    interpreter.subscribe((e) => events.push(e));
+
+    const touch = makeTouch(0, 100, 100);
+    element.dispatchEvent(makeTouchStartEvent([touch]));
+    element.dispatchEvent(makeTouchEndEvent(touch));
+    element.dispatchEvent(makeTouchStartEvent([touch]));
+    element.dispatchEvent(makeTouchEndEvent(touch));
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("toggle-zoom");
+    interpreter.unmount();
+  });
+
+  it("sets touch double-tap origin relative to element top-left", () => {
+    vi.spyOn(element, "getBoundingClientRect").mockReturnValue({
+      left: 20,
+      top: 10,
+      right: 220,
+      bottom: 210,
+      width: 200,
+      height: 200,
+      x: 20,
+      y: 10,
+      toJSON: () => {},
+    });
+
+    const interpreter = doubleTapInterpreter()(element);
+    const events: InterpreterEvent[] = [];
+    interpreter.subscribe((e) => events.push(e));
+
+    const touch = makeTouch(0, 120, 110);
+    element.dispatchEvent(makeTouchStartEvent([touch]));
+    element.dispatchEvent(makeTouchEndEvent(touch));
+    element.dispatchEvent(makeTouchStartEvent([touch]));
+    element.dispatchEvent(makeTouchEndEvent(touch));
+
+    expect(events[0].type).toBe("toggle-zoom");
+    if (events[0].type === "toggle-zoom") {
+      expect(events[0].originX).toBe(100); // 120 - 20
+      expect(events[0].originY).toBe(100); // 110 - 10
+    }
+    interpreter.unmount();
+  });
+
+  it("does not emit when second tap is too far from first", () => {
+    const interpreter = doubleTapInterpreter()(element);
+    const events: InterpreterEvent[] = [];
+    interpreter.subscribe((e) => events.push(e));
+
+    const touch1 = makeTouch(0, 100, 100);
+    const touch2 = makeTouch(0, 200, 200); // ~141 px away
+
+    element.dispatchEvent(makeTouchStartEvent([touch1]));
+    element.dispatchEvent(makeTouchEndEvent(touch1));
+    element.dispatchEvent(makeTouchStartEvent([touch2]));
+    element.dispatchEvent(makeTouchEndEvent(touch2));
+
+    expect(events).toHaveLength(0);
+    interpreter.unmount();
+  });
+
+  it("resets state on multi-touch: tap after multi-touch does not count as second of a pair", () => {
+    const interpreter = doubleTapInterpreter()(element);
+    const events: InterpreterEvent[] = [];
+    interpreter.subscribe((e) => events.push(e));
+
+    const touch1 = makeTouch(0, 100, 100);
+    const touch2 = makeTouch(1, 150, 100);
+
+    // First tap → awaiting
+    element.dispatchEvent(makeTouchStartEvent([touch1]));
+    element.dispatchEvent(makeTouchEndEvent(touch1));
+
+    // Multi-touch → state resets to idle
+    element.dispatchEvent(makeTouchStartEvent([touch1, touch2]));
+
+    // Single tap → this becomes a fresh first tap (not a second tap)
+    element.dispatchEvent(makeTouchStartEvent([touch1]));
+    element.dispatchEvent(makeTouchEndEvent(touch1));
+
+    expect(events).toHaveLength(0); // no toggle-zoom yet
+    interpreter.unmount();
+  });
+
+  it("stops emitting after unmount", () => {
+    const interpreter = doubleTapInterpreter()(element);
+    const events: InterpreterEvent[] = [];
+    interpreter.subscribe((e) => events.push(e));
+    interpreter.unmount();
+
+    element.dispatchEvent(
+      new MouseEvent("dblclick", { clientX: 100, clientY: 100, bubbles: true }),
+    );
+
+    expect(events).toHaveLength(0);
+  });
+});

--- a/packages/core/src/interpreter/double-tap.ts
+++ b/packages/core/src/interpreter/double-tap.ts
@@ -1,0 +1,108 @@
+import type {
+  Interpreter,
+  MountedInterpreter,
+  Callback,
+  InterpreterEvent,
+  UnsubscribeFn,
+} from "../types.js";
+
+const DOUBLE_TAP_TIME_MS = 300;
+const DOUBLE_TAP_DISTANCE_PX = 30;
+
+type DoubleTapState =
+  | { type: "idle" }
+  | { type: "awaiting_second_tap"; x: number; y: number; timestamp: number };
+
+export function doubleTapInterpreter(): Interpreter {
+  return (element: Element): MountedInterpreter => {
+    const callbacks = new Set<Callback<InterpreterEvent>>();
+    let state: DoubleTapState = { type: "idle" };
+
+    function emit(event: InterpreterEvent) {
+      for (const cb of callbacks) cb(event);
+    }
+
+    function onDblClick(e: MouseEvent) {
+      const rect = element.getBoundingClientRect();
+      emit({
+        type: "toggle-zoom",
+        originX: e.clientX - rect.left,
+        originY: e.clientY - rect.top,
+        timestamp: e.timeStamp,
+      });
+    }
+
+    function onTouchStart(e: TouchEvent) {
+      if (e.touches.length !== 1) {
+        state = { type: "idle" };
+      }
+    }
+
+    function onTouchEnd(e: TouchEvent) {
+      if (e.changedTouches.length !== 1 || e.touches.length !== 0) {
+        state = { type: "idle" };
+        return;
+      }
+      const touch = e.changedTouches[0];
+      const x = touch.clientX;
+      const y = touch.clientY;
+      const timestamp = e.timeStamp;
+
+      if (state.type === "awaiting_second_tap") {
+        const dt = timestamp - state.timestamp;
+        const dx = x - state.x;
+        const dy = y - state.y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+
+        if (dt <= DOUBLE_TAP_TIME_MS && dist <= DOUBLE_TAP_DISTANCE_PX) {
+          state = { type: "idle" };
+          const rect = element.getBoundingClientRect();
+          emit({
+            type: "toggle-zoom",
+            originX: x - rect.left,
+            originY: y - rect.top,
+            timestamp,
+          });
+          return;
+        }
+      }
+
+      state = { type: "awaiting_second_tap", x, y, timestamp };
+    }
+
+    function onTouchCancel() {
+      state = { type: "idle" };
+    }
+
+    element.addEventListener("dblclick", onDblClick as EventListener);
+    element.addEventListener("touchstart", onTouchStart as EventListener, {
+      passive: true,
+    });
+    element.addEventListener("touchend", onTouchEnd as EventListener, {
+      passive: true,
+    });
+    element.addEventListener("touchcancel", onTouchCancel as EventListener, {
+      passive: true,
+    });
+
+    return {
+      subscribe(cb: Callback<InterpreterEvent>): UnsubscribeFn {
+        callbacks.add(cb);
+        return () => callbacks.delete(cb);
+      },
+      unmount() {
+        element.removeEventListener("dblclick", onDblClick as EventListener);
+        element.removeEventListener(
+          "touchstart",
+          onTouchStart as EventListener,
+        );
+        element.removeEventListener("touchend", onTouchEnd as EventListener);
+        element.removeEventListener(
+          "touchcancel",
+          onTouchCancel as EventListener,
+        );
+        callbacks.clear();
+      },
+    };
+  };
+}

--- a/packages/core/src/interpreter/index.ts
+++ b/packages/core/src/interpreter/index.ts
@@ -1,3 +1,4 @@
 export { touchInterpreter } from "./touch.js";
 export { mouseDragInterpreter } from "./mouse-drag.js";
 export { mouseWheelInterpreter } from "./mouse-wheel.js";
+export { doubleTapInterpreter } from "./double-tap.js";

--- a/packages/core/src/model/__tests__/carousel.test.ts
+++ b/packages/core/src/model/__tests__/carousel.test.ts
@@ -795,6 +795,110 @@ describe("createCarouselModel", () => {
   });
 
   // -------------------------------------------------------------------------
+  // toggle-zoom
+  // -------------------------------------------------------------------------
+
+  describe("toggle-zoom", () => {
+    function toggleZoom(
+      opts: Partial<{ itemId: string; originX: number; originY: number }> = {},
+    ) {
+      return {
+        type: "toggle-zoom" as const,
+        originX: 0,
+        originY: 0,
+        timestamp: 0,
+        ...opts,
+      };
+    }
+
+    it("free state: routes to the targeted item", () => {
+      const reduce = makeReduce();
+      const state = reduce(free(), toggleZoom({ itemId: "a" }));
+      expect(state.type).toBe("free");
+      expect(state.items.a.type).toBe("snapping");
+      expect(state.items.b.type).toBe("settled");
+    });
+
+    it("free state: zooms in to 2x centered at origin", () => {
+      const reduce = makeReduce();
+      const state = reduce(
+        free(),
+        toggleZoom({ itemId: "a", originX: 100, originY: 80 }),
+      );
+      expect(state.items.a.type).toBe("snapping");
+      if (state.items.a.type === "snapping") {
+        expect(state.items.a.target.scale).toBe(2);
+        expect(state.items.a.target.x).toBeCloseTo(-100);
+        expect(state.items.a.target.y).toBeCloseTo(-80);
+      }
+    });
+
+    it("free state: zooms out when item is already zoomed in", () => {
+      const reduce = makeReduce();
+      const state = reduce(
+        free(0, { a: { x: -50, y: -50, scale: 2 } }),
+        toggleZoom({ itemId: "a" }),
+      );
+      expect(state.items.a.type).toBe("snapping");
+      if (state.items.a.type === "snapping") {
+        expect(state.items.a.target).toEqual({ x: 0, y: 0, scale: 1 });
+      }
+    });
+
+    it("free state: ignored when itemId is absent (same reference)", () => {
+      const reduce = makeReduce();
+      const before = free();
+      expect(reduce(before, toggleZoom())).toBe(before);
+    });
+
+    it("free state: ignored for unknown itemId (same reference)", () => {
+      const reduce = makeReduce();
+      const before = free();
+      expect(reduce(before, toggleZoom({ itemId: "unknown" }))).toBe(before);
+    });
+
+    it("carousel state: ignored (same reference)", () => {
+      const reduce = makeReduce();
+      const before = makeCarouselTrackingState();
+      expect(reduce(before, toggleZoom({ itemId: "a" }))).toBe(before);
+    });
+
+    it("items state: routes to the active item", () => {
+      const reduce = makeReduce();
+      // item "a" is settled and zoomed in; toggle-zoom should snap it back out
+      const itemsWithSettledItem: CarouselPrivateState = {
+        type: "items",
+        carousel: makeSettledCarousel(),
+        items: {
+          a: makeSettledItem(-50, -50, 2),
+          b: makeSettledItem(),
+          c: makeSettledItem(),
+        },
+        activeItemId: "a",
+      };
+      const state = reduce(itemsWithSettledItem, toggleZoom({ itemId: "a" }));
+      expect(state.type).toBe("items");
+      expect(state.items.a.type).toBe("snapping");
+    });
+
+    it("items state: ignored for a non-active item (same reference)", () => {
+      const reduce = makeReduce();
+      // item "a" is settled and zoomed in
+      const before: CarouselPrivateState = {
+        type: "items",
+        carousel: makeSettledCarousel(),
+        items: {
+          a: makeSettledItem(-50, -50, 2),
+          b: makeSettledItem(),
+          c: makeSettledItem(),
+        },
+        activeItemId: "a",
+      };
+      expect(reduce(before, toggleZoom({ itemId: "b" }))).toBe(before);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // publish
   // -------------------------------------------------------------------------
 

--- a/packages/core/src/model/__tests__/transform.test.ts
+++ b/packages/core/src/model/__tests__/transform.test.ts
@@ -336,4 +336,118 @@ describe("createTransformReduce", () => {
       expect(state.x.value).toBeCloseTo(100, 0);
     });
   });
+
+  describe("toggle-zoom", () => {
+    function toggleZoom(originX = 0, originY = 0) {
+      return {
+        type: "toggle-zoom" as const,
+        originX,
+        originY,
+        timestamp: 0,
+      };
+    }
+
+    it("settled at scale=1 transitions to snapping targeting 2x", () => {
+      const reduce = createTransformReduce();
+      const state = reduce(
+        { type: "settled", ...makeTransform() },
+        toggleZoom(100, 80),
+      );
+      expect(state.type).toBe("snapping");
+      if (state.type === "snapping") {
+        expect(state.target.scale).toBe(2);
+      }
+    });
+
+    it("zoom-in snap target pins the tap point", () => {
+      // tap at (100, 80), scale 1→2: targetX = 100*(1-2)+0*2 = -100
+      const reduce = createTransformReduce();
+      const state = reduce(
+        { type: "settled", ...makeTransform() },
+        toggleZoom(100, 80),
+      );
+      if (state.type === "snapping") {
+        expect(state.target.x).toBeCloseTo(-100);
+        expect(state.target.y).toBeCloseTo(-80);
+      }
+    });
+
+    it("settled at scale=2 transitions to snapping targeting (0,0,1)", () => {
+      const reduce = createTransformReduce();
+      const state = reduce(
+        { type: "settled", ...makeTransform(-50, -50, 2) },
+        toggleZoom(100, 80),
+      );
+      expect(state.type).toBe("snapping");
+      if (state.type === "snapping") {
+        expect(state.target).toEqual({ x: 0, y: 0, scale: 1 });
+      }
+    });
+
+    it("inertia transitions to snapping (interrupts inertia)", () => {
+      const reduce = createTransformReduce();
+      const state = reduce(
+        {
+          type: "inertia",
+          origin: { x: 0, y: 0 },
+          ...makeTransformWithVelocity(5, 0),
+        },
+        toggleZoom(100, 80),
+      );
+      expect(state.type).toBe("snapping");
+    });
+
+    it("tracking is ignored", () => {
+      const reduce = createTransformReduce();
+      const before: TransformPrivateState = {
+        type: "tracking",
+        origin: { x: 0, y: 0 },
+        ...makeTransform(),
+      };
+      expect(reduce(before, toggleZoom())).toBe(before);
+    });
+
+    it("snapping is ignored", () => {
+      const reduce = createTransformReduce();
+      const before: TransformPrivateState = {
+        type: "snapping",
+        ...makeTransform(60),
+        target: { x: 100, y: 0, scale: 1 },
+      };
+      expect(reduce(before, toggleZoom())).toBe(before);
+    });
+
+    it("zoom-in target is clamped to bounds", () => {
+      // itemWidth=400: bounds(2) = { minX: -400, maxX: 0 }
+      // tap at originX=500: proposed targetX = 500*(1-2)+0*2 = -500, clamped to -400
+      const reduce = createTransformReduce({
+        bounds: (scale) => ({
+          minX: 400 * (1 - scale),
+          maxX: 0,
+          minY: 600 * (1 - scale),
+          maxY: 0,
+        }),
+      });
+      const state = reduce(
+        { type: "settled", ...makeTransform() },
+        toggleZoom(500, 0),
+      );
+      if (state.type === "snapping") {
+        expect(state.target.x).toBeCloseTo(-400);
+      }
+    });
+
+    it("respects custom toggleZoomScale", () => {
+      const reduce = createTransformReduce({ toggleZoomScale: 3 });
+      const state = reduce(
+        { type: "settled", ...makeTransform() },
+        toggleZoom(100, 0),
+      );
+      if (state.type === "snapping") {
+        expect(state.target.scale).toBe(3);
+        // targetX = 100*(1-3)+0*3 = -200
+        expect(state.target.x).toBeCloseTo(-200);
+      }
+    });
+  });
 });

--- a/packages/core/src/model/carousel.ts
+++ b/packages/core/src/model/carousel.ts
@@ -273,6 +273,18 @@ function createCarouselReduce(config: CarouselConfig) {
           }
           case "release":
             return state;
+          case "toggle-zoom": {
+            if (action.itemId === undefined) return state;
+            const item = state.items[action.itemId];
+            if (!item) return state;
+            return {
+              ...state,
+              items: {
+                ...state.items,
+                [action.itemId]: itemReduce(item, action),
+              },
+            };
+          }
           case "tick": {
             const carousel = carouselReduce(state.carousel, action);
             const items = advanceAllItems(state.items, action.timestamp);
@@ -309,6 +321,8 @@ function createCarouselReduce(config: CarouselConfig) {
             const carousel = carouselReduce(state.carousel, action);
             return { type: "free", carousel, items: state.items };
           }
+          case "toggle-zoom":
+            return state;
           case "tick": {
             const carousel = carouselReduce(state.carousel, action);
             const items = advanceAllItems(state.items, action.timestamp);
@@ -344,6 +358,19 @@ function createCarouselReduce(config: CarouselConfig) {
               ),
             };
             return { type: "free", carousel: state.carousel, items };
+          }
+          case "toggle-zoom": {
+            if (action.itemId !== state.activeItemId) return state;
+            return {
+              ...state,
+              items: {
+                ...state.items,
+                [state.activeItemId]: itemReduce(
+                  state.items[state.activeItemId],
+                  action,
+                ),
+              },
+            };
           }
           case "tick": {
             const carousel = carouselReduce(state.carousel, action);

--- a/packages/core/src/model/transform.ts
+++ b/packages/core/src/model/transform.ts
@@ -25,6 +25,8 @@ export type TransformConfig = {
     y: LinearPrimitive;
     scale: ExponentialPrimitive;
   }) => TransformSnapTarget | null;
+  /** Scale factor to apply when zooming in via double-tap. Defaults to 2. */
+  toggleZoomScale?: number;
 };
 
 type Origin = { x: number; y: number };
@@ -77,7 +79,30 @@ export function settleTransform(state: {
 }
 
 export function createTransformReduce(config?: TransformConfig) {
-  const { bounds, snapTarget } = config ?? {};
+  const { bounds, snapTarget, toggleZoomScale = 2 } = config ?? {};
+
+  function computeToggleZoomTarget(
+    state: {
+      x: LinearPrimitive;
+      y: LinearPrimitive;
+      scale: ExponentialPrimitive;
+    },
+    originX: number,
+    originY: number,
+  ): TransformSnapTarget {
+    if (Math.abs(state.scale.value - 1) < 0.01) {
+      const ds = toggleZoomScale / state.scale.value;
+      let targetX = originX * (1 - ds) + state.x.value * ds;
+      let targetY = originY * (1 - ds) + state.y.value * ds;
+      if (bounds) {
+        const b = bounds(toggleZoomScale);
+        targetX = Math.max(b.minX, Math.min(b.maxX, targetX));
+        targetY = Math.max(b.minY, Math.min(b.maxY, targetY));
+      }
+      return { x: targetX, y: targetY, scale: toggleZoomScale };
+    }
+    return { x: 0, y: 0, scale: 1 };
+  }
 
   return function reduce(
     state: TransformPrivateState | undefined = {
@@ -152,6 +177,8 @@ export function createTransformReduce(config?: TransformConfig) {
           }
           case "tick":
             return state;
+          case "toggle-zoom":
+            return state;
         }
         throw new Error("unreachable");
       }
@@ -219,6 +246,18 @@ export function createTransformReduce(config?: TransformConfig) {
               scale: newScale,
             };
           }
+          case "toggle-zoom":
+            return {
+              type: "snapping",
+              x: state.x,
+              y: state.y,
+              scale: state.scale,
+              target: computeToggleZoomTarget(
+                state,
+                action.originX,
+                action.originY,
+              ),
+            };
         }
         throw new Error("unreachable");
       }
@@ -233,6 +272,8 @@ export function createTransformReduce(config?: TransformConfig) {
               scale: state.scale,
             };
           case "release":
+            return state;
+          case "toggle-zoom":
             return state;
           case "tick": {
             if (
@@ -292,6 +333,18 @@ export function createTransformReduce(config?: TransformConfig) {
             return state;
           case "tick":
             return state;
+          case "toggle-zoom":
+            return {
+              type: "snapping",
+              x: state.x,
+              y: state.y,
+              scale: state.scale,
+              target: computeToggleZoomTarget(
+                state,
+                action.originX,
+                action.originY,
+              ),
+            };
         }
         throw new Error("unreachable");
       }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -18,6 +18,15 @@ export type InterpreterEvent =
       type: "release";
       /** Identifies the item being released. Absent for container-level gestures. */
       itemId?: string;
+    }
+  | {
+      type: "toggle-zoom";
+      /** Identifies the item being double-tapped. Absent for container-level gestures. */
+      itemId?: string;
+      /** Double-tap position relative to the element's top-left corner (px). */
+      originX: number;
+      originY: number;
+      timestamp: number;
     };
 
 // TODO: Move to a new module

--- a/packages/demo/src/ScalableCarouselContainer.tsx
+++ b/packages/demo/src/ScalableCarouselContainer.tsx
@@ -7,6 +7,7 @@ import {
   type MountedInterpreter,
   type InterpreterEvent,
   mouseWheelInterpreter,
+  doubleTapInterpreter,
 } from "@mimosa/core";
 
 type ScalableCarouselItem = {
@@ -57,6 +58,7 @@ export function ScalableCarouselContainer({
         withItemId(touchInterpreter()(viewport), item.id),
         withItemId(mouseDragInterpreter()(viewport), item.id),
         withItemId(mouseWheelInterpreter()(viewport), item.id),
+        withItemId(doubleTapInterpreter()(viewport), item.id),
       );
     }
 


### PR DESCRIPTION
## Summary

- Adds a `toggle-zoom` `InterpreterEvent` carrying the tap origin (`originX`, `originY`, `timestamp`, optional `itemId`).
- Adds `doubleTapInterpreter`: emits `toggle-zoom` on native `dblclick` (mouse) and on two consecutive single-finger taps within 300 ms / 30 px (touch).
- `createTransformReduce` handles `toggle-zoom`: zooms in to `toggleZoomScale` (default 2×, configurable via `TransformConfig`) centred on the tap point when at scale ≈ 1, snaps back to `(0, 0, 1)` when already zoomed. Ignored in `tracking` and `snapping` states.
- `createCarouselReduce` routes `toggle-zoom` to the targeted item in `free` and `items` states; ignored in `carousel` state.
- `ScalableCarouselContainer` in the demo wires `doubleTapInterpreter` per item alongside the existing interpreters.
- Tests added for `doubleTapInterpreter`, `createTransformReduce` (toggle-zoom branch), and `createCarouselReduce` (toggle-zoom routing).

## Test plan

- [ ] `npm run tsc && npm run format && npm run lint && npm run test` passes (118 tests across 9 files).
- [ ] In the demo, double-clicking (mouse) or double-tapping (touch) an item zooms it in to 2× centred on the tap point.
- [ ] A second double-tap zooms back out to 1×.
- [ ] Double-tapping while the carousel strip is scrolling does nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)