### PR TITLE
Ensure carousel items can be dynamically updated

### DIFF
--- a/design/00_architecture.md
+++ b/design/00_architecture.md
@@ -166,7 +166,7 @@ type Options = {
 
 #### Multi-Item Carousel Model
 
-A Model for multi-item carousels that support per-item pinch-to-zoom.:
+A Model for multi-item carousels that support per-item pinch-to-zoom. Its action type extends `StoreAction` with a `set-config` action that allows changing the item list at runtime:
 
 ```typescript
 type Options = {
@@ -174,7 +174,11 @@ type Options = {
   itemHeight: number;  // item container height (px)
   itemIds: readonly string[];  // ordered list of item identifiers
 };
+
+type CarouselAction = StoreAction | { type: "set-config"; config: CarouselConfig };
 ```
+
+Dispatching `set-config` updates the item list while preserving carousel animation state. The carousel strip stays anchored to the item the gesture was heading toward; deleted items lose their transform state; new items start at the neutral transform. If the active item (currently being panned/zoomed) is deleted, the model transitions immediately to the `free` state.
 
 #### Transform and TransformVelocity
 
@@ -197,15 +201,19 @@ The Store has a continuous update loop driven by `requestAnimationFrame()`. Moti
 The Store's update loop emits state to subscribers on every frame where the state changes. The loop pauses automatically when the reducer returns the same object reference as the previous state (indicating the state has settled), and resumes when an Interpreter emits a new event. This pause/resume behavior is an implementation detail of the Store — other modules must not depend on it. The reference equality contract described in [State Machine Design](#state-machine-design) is what enables this optimization.
 
 ```typescript
-type Store<TState> = (interpreters: MountedInterpreter[]) => MountedStore<TState>;
-type MountedStore<TState> = {
+type Store<TState, TAction = StoreAction> = (interpreters: MountedInterpreter[]) => MountedStore<TState, TAction>;
+type MountedStore<TState, TAction = StoreAction> = {
   subscribe: (cb: Callback<TState>) => UnsubscribeFn;
+  /** Dispatches an action directly into the model (e.g. set-config). */
+  dispatch: (action: TAction) => void;
+  /** Subscribes a new interpreter after store creation. Returns an unmount fn. */
+  mount: (interpreter: MountedInterpreter) => UnmountFn;
   unmount: UnmountFn;
 };
 
-declare function createStore<TPrivateState, TState>(
-  model: Model<TState, TPrivateState, StoreAction>,
-): Store<TState>;
+declare function createStore<TPrivateState, TState, TAction = StoreAction>(
+  model: Model<TState, TPrivateState, TAction>,
+): Store<TState, TAction>;
 ```
 
 Mounting the `MountedInterpreter[]` passed to the Store (i.e., calling the Interpreters) is the responsibility of the caller.

--- a/design/00_architecture.md
+++ b/design/00_architecture.md
@@ -150,7 +150,7 @@ The Model module provides factory functions for several pre-built Models for com
 
 
 ```typescript
-declare function createModel(options: { /* model-specific options */ }): Model<State, TransformPrivateState, StoreAction>;
+declare function createModel(options: { /* model-specific options */ }): Model<State, TransformPrivateState, TransformAction>;
 ```
 
 #### Single-Item Transform Model
@@ -175,7 +175,7 @@ type Options = {
   itemIds: readonly string[];  // ordered list of item identifiers
 };
 
-type CarouselAction = StoreAction | { type: "set-config"; config: CarouselConfig };
+type CarouselAction = TransformAction | { type: "set-config"; config: CarouselConfig };
 ```
 
 Dispatching `set-config` updates the item list while preserving carousel animation state. The carousel strip stays anchored to the item the gesture was heading toward; deleted items lose their transform state; new items start at the neutral transform. If the active item (currently being panned/zoomed) is deleted, the model transitions immediately to the `free` state.
@@ -194,34 +194,30 @@ Velocity is internal state and is not included in the public `State`.
 
 ## Store Module
 
-The Store module is a generic animation loop. It subscribes to Interpreter events, applies them to a reducer, and emits the resulting public state to subscribers on every animation frame.
+The Store module is a generic animation loop. It drives the animation frame, dispatches tick actions on each frame to advance inertia or spring animations, and emits the resulting public state to subscribers.
 
-The Store has a continuous update loop driven by `requestAnimationFrame()`. Motion events received from Interpreters are applied to the reducer. The tick action is dispatched on each frame to advance inertia or spring animations.
+The Store has a continuous update loop driven by `requestAnimationFrame()`. The tick action is dispatched on each frame. Gesture events from Interpreters reach the reducer via `dispatch`, which the caller wires up externally.
 
-The Store's update loop emits state to subscribers on every frame where the state changes. The loop pauses automatically when the reducer returns the same object reference as the previous state (indicating the state has settled), and resumes when an Interpreter emits a new event. This pause/resume behavior is an implementation detail of the Store — other modules must not depend on it. The reference equality contract described in [State Machine Design](#state-machine-design) is what enables this optimization.
+The Store's update loop emits state to subscribers on every frame where the state changes. The loop pauses automatically when the reducer returns the same object reference as the previous state (indicating the state has settled), and resumes when `dispatch` is called. This pause/resume behavior is an implementation detail of the Store — other modules must not depend on it. The reference equality contract described in [State Machine Design](#state-machine-design) is what enables this optimization.
 
 ```typescript
-type Store<TState, TAction = StoreAction> = (interpreters: MountedInterpreter[]) => MountedStore<TState, TAction>;
-type MountedStore<TState, TAction = StoreAction> = {
+type Store<TState, TAction = StoreAction> = {
   subscribe: (cb: Callback<TState>) => UnsubscribeFn;
-  /** Dispatches an action directly into the model (e.g. set-config). */
   dispatch: (action: TAction) => void;
-  /** Subscribes a new interpreter after store creation. Returns an unmount fn. */
-  mount: (interpreter: MountedInterpreter) => UnmountFn;
   unmount: UnmountFn;
 };
 
-declare function createStore<TPrivateState, TState, TAction = StoreAction>(
-  model: Model<TState, TPrivateState, TAction>,
-): Store<TState, TAction>;
+declare function createStore<TPrivateState, TState, TExtraAction = never>(
+  model: Model<TState, TPrivateState, StoreAction | TExtraAction>,
+): Store<TState, StoreAction | TExtraAction>;
 ```
 
-Mounting the `MountedInterpreter[]` passed to the Store (i.e., calling the Interpreters) is the responsibility of the caller.
-
-To create a transform store with the default Model:
+To create a transform store and wire up interpreters:
 
 ```typescript
 const store = createStore(createModel(snapConfig));
+const stops = interpreters.map(i => i.subscribe(e => store.dispatch(e)));
+// Later: stops.forEach(stop => stop()); store.unmount(); interpreters.forEach(i => i.unmount());
 ```
 
 ## Renderer Module
@@ -231,7 +227,7 @@ The Renderer module receives transform information from the Store and applies it
 The Renderer subscribes to the Store and updates the target element's CSS transform whenever State changes. The Renderer holds no internal state and is responsible only for side effects (DOM updates).
 
 ```typescript
-type Renderer = (element: Element, store: MountedStore) => MountedRenderer;
+type Renderer = (element: Element, store: Store) => MountedRenderer;
 type MountedRenderer = {
   unmount: UnmountFn;
 };
@@ -242,7 +238,7 @@ declare function createRenderer(): Renderer;
 ## Module Dependencies
 
 - The Renderer depends on the Store. The Renderer subscribes to the Store's state and applies transformations to the target element.
-- The Store depends on the Interpreter and the Model. The Store wires them together into an animation loop.
+- The Store depends on the Model. The Store drives the animation loop and forwards externally dispatched actions to the Model.
 - The Model does not depend on the Store, Interpreter, or Renderer. It is a pure function from state and action to state.
 - The Interpreter does not depend on the Store, Model, or Renderer. The Interpreter focuses solely on processing user input and generating Motion.
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,4 +26,5 @@ export {
   createCarouselModel,
   type CarouselConfig,
   type CarouselPublicState,
+  type CarouselAction,
 } from "./model/index.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,6 @@ export type {
   State,
   MountedInterpreter,
   Interpreter,
-  MountedStore,
   Store,
   MountedRenderer,
   Renderer,

--- a/packages/core/src/model/__tests__/carousel.test.ts
+++ b/packages/core/src/model/__tests__/carousel.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { createCarouselModel, type CarouselPrivateState } from "../carousel.js";
+import {
+  createCarouselModel,
+  type CarouselPrivateState,
+  type CarouselAction,
+} from "../carousel.js";
 import type { TransformPrivateState } from "../index.js";
 
 const ITEM_WIDTH = 400;
@@ -75,13 +79,19 @@ function free(
     const { x = 0, y = 0, scale = 1 } = itemOverrides[id] ?? {};
     items[id] = makeSettledItem(x, y, scale);
   }
-  return { type: "free", carousel: makeSettledCarousel(carouselX), items };
+  return {
+    type: "free",
+    itemIds: ITEM_IDS,
+    carousel: makeSettledCarousel(carouselX),
+    items,
+  };
 }
 
 /** Returns a carousel state with a tracking carousel strip. */
 function makeCarouselTrackingState(carouselX = 0): CarouselPrivateState {
   return {
     type: "carousel",
+    itemIds: ITEM_IDS,
     carousel: {
       type: "tracking",
       origin: { x: carouselX, y: 0 },
@@ -107,6 +117,7 @@ function makeItemsState(
 ): CarouselPrivateState {
   return {
     type: "items",
+    itemIds: ITEM_IDS,
     carousel: makeSettledCarousel(),
     items: {
       a: makeTrackingItem(aConfig.x, aConfig.y, aConfig.scale),
@@ -183,6 +194,7 @@ describe("createCarouselModel", () => {
       const reduce = makeReduce();
       const state: CarouselPrivateState = {
         type: "free",
+        itemIds: ITEM_IDS,
         carousel: makeSettledCarousel(),
         items: {
           a: makeInertiaItem(-50, 0, 2, -5),
@@ -286,6 +298,7 @@ describe("createCarouselModel", () => {
       const reduce = makeReduce();
       const freeWithInertia: CarouselPrivateState = {
         type: "free",
+        itemIds: ITEM_IDS,
         carousel: makeSettledCarousel(),
         items: {
           a: makeInertiaItem(-50, 0, 2, -5),
@@ -306,6 +319,7 @@ describe("createCarouselModel", () => {
       const reduce = makeReduce();
       const freeWithInertia: CarouselPrivateState = {
         type: "free",
+        itemIds: ITEM_IDS,
         carousel: makeSettledCarousel(),
         items: {
           a: makeInertiaItem(-50, 0, 2, -5),
@@ -372,6 +386,7 @@ describe("createCarouselModel", () => {
       // x=-100, velocity=-2 px/ms → projected ≈ -100 - 199 = -299 → snaps to -400
       const flickState: CarouselPrivateState = {
         type: "carousel",
+        itemIds: ITEM_IDS,
         carousel: {
           type: "tracking",
           origin: { x: 0, y: 0 },
@@ -397,6 +412,7 @@ describe("createCarouselModel", () => {
       // x=-300, velocity=+2 px/ms → projected ≈ -300 + 199 = -101 → snaps to 0
       const flickBackState: CarouselPrivateState = {
         type: "carousel",
+        itemIds: ITEM_IDS,
         carousel: {
           type: "tracking",
           origin: { x: 0, y: 0 },
@@ -442,6 +458,7 @@ describe("createCarouselModel", () => {
       const reduce = makeReduce();
       const state: CarouselPrivateState = {
         type: "carousel",
+        itemIds: ITEM_IDS,
         carousel: {
           type: "tracking",
           origin: { x: 0, y: 0 },
@@ -466,6 +483,7 @@ describe("createCarouselModel", () => {
       const reduce = makeReduce();
       const freeWithInertia: CarouselPrivateState = {
         type: "free",
+        itemIds: ITEM_IDS,
         carousel: makeSettledCarousel(),
         items: {
           a: makeInertiaItem(-50, 0, 2, -5),
@@ -558,6 +576,7 @@ describe("createCarouselModel", () => {
       const reduce = makeReduce();
       const itemsWithVelocity: CarouselPrivateState = {
         type: "items",
+        itemIds: ITEM_IDS,
         carousel: makeSettledCarousel(),
         items: {
           a: {
@@ -588,6 +607,7 @@ describe("createCarouselModel", () => {
       const reduce = makeReduce();
       const state: CarouselPrivateState = {
         type: "items",
+        itemIds: ITEM_IDS,
         carousel: {
           type: "snapping",
           transform: { x: -200, y: 0, scale: 1 },
@@ -616,6 +636,7 @@ describe("createCarouselModel", () => {
     function makeSettledCarouselWithInertiaItem(): CarouselPrivateState {
       return {
         type: "free",
+        itemIds: ITEM_IDS,
         carousel: makeSettledCarousel(),
         items: {
           a: makeInertiaItem(-50, 0, 2, -5),
@@ -658,6 +679,7 @@ describe("createCarouselModel", () => {
       const reduce = makeReduce();
       const state: CarouselPrivateState = {
         type: "free",
+        itemIds: ITEM_IDS,
         carousel: makeSettledCarousel(),
         items: {
           a: makeInertiaItem(-50, 0, 2), // no velocity → settles immediately
@@ -674,6 +696,7 @@ describe("createCarouselModel", () => {
       const reduce = makeReduce();
       const state: CarouselPrivateState = {
         type: "free",
+        itemIds: ITEM_IDS,
         carousel: makeSettledCarousel(),
         items: {
           a: makeInertiaItem(-50, -30, 2),
@@ -696,6 +719,7 @@ describe("createCarouselModel", () => {
     function makeSnappingItemState(): CarouselPrivateState {
       return {
         type: "free",
+        itemIds: ITEM_IDS,
         carousel: makeSettledCarousel(),
         items: {
           a: {
@@ -744,6 +768,7 @@ describe("createCarouselModel", () => {
     ): CarouselPrivateState {
       return {
         type: "free",
+        itemIds: ITEM_IDS,
         carousel: {
           type: "snapping",
           transform: { x: carouselX, y: 0, scale: 1 },
@@ -900,6 +925,7 @@ describe("createCarouselModel", () => {
       // item "a" is settled and zoomed in; toggle-zoom should snap it back out
       const itemsWithSettledItem: CarouselPrivateState = {
         type: "items",
+        itemIds: ITEM_IDS,
         carousel: makeSettledCarousel(),
         items: {
           a: makeSettledItem(-50, -50, 2),
@@ -918,6 +944,7 @@ describe("createCarouselModel", () => {
       // item "a" is settled and zoomed in
       const before: CarouselPrivateState = {
         type: "items",
+        itemIds: ITEM_IDS,
         carousel: makeSettledCarousel(),
         items: {
           a: makeSettledItem(-50, -50, 2),
@@ -927,6 +954,116 @@ describe("createCarouselModel", () => {
         activeItemId: "a",
       };
       expect(reduce(before, toggleZoom({ itemId: "b" }))).toBe(before);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // set-config
+  // -------------------------------------------------------------------------
+
+  describe("set-config", () => {
+    function setConfig(newItemIds: readonly string[]): CarouselAction {
+      return {
+        type: "set-config",
+        config: {
+          itemWidth: ITEM_WIDTH,
+          itemHeight: ITEM_HEIGHT,
+          itemIds: newItemIds,
+        },
+      };
+    }
+
+    it("adds new items with neutral transform", () => {
+      const reduce = makeReduce();
+      const state = reduce(free(), setConfig(["a", "b", "c", "d"]));
+      expect(state.items.d).toBeDefined();
+      expect(state.items.d.transform).toEqual({ x: 0, y: 0, scale: 1 });
+    });
+
+    it("removes deleted items", () => {
+      const reduce = makeReduce();
+      const state = reduce(free(), setConfig(["a", "b"]));
+      expect(state.items.c).toBeUndefined();
+      expect(Object.keys(state.items)).toHaveLength(2);
+    });
+
+    it("preserves transform state of surviving items", () => {
+      const reduce = makeReduce();
+      const state = reduce(
+        free(0, { a: { x: -50, y: -30, scale: 2 } }),
+        setConfig(["a", "b"]),
+      );
+      expect(state.items.a.transform).toEqual({ x: -50, y: -30, scale: 2 });
+    });
+
+    it("keeps carousel anchored on current item when an earlier item is deleted", () => {
+      // Settled on item "b" (index 1 → x=-400). After deleting "a", "b" is at index 0.
+      // Carousel should shift to x=0 so "b" stays on screen.
+      const reduce = makeReduce();
+      const state = reduce(free(-ITEM_WIDTH), setConfig(["b", "c"]));
+      expect(state.carousel.transform.x).toBeCloseTo(0);
+    });
+
+    it("keeps carousel anchored when an earlier item is inserted", () => {
+      // Settled on item "a" (index 0 → x=0). After inserting "z" before "a", "a" is at index 1.
+      // Carousel should shift to x=-400 so "a" stays on screen.
+      const reduce = makeReduce();
+      const state = reduce(free(0), setConfig(["z", "a", "b", "c"]));
+      expect(state.carousel.transform.x).toBeCloseTo(-ITEM_WIDTH);
+    });
+
+    it("snapping state: shifts both transform.x and target.x", () => {
+      const reduce = makeReduce();
+      // Carousel snapping toward item "b" (index 1, x=-400). Delete "a" → "b" moves to index 0.
+      const snapping: CarouselPrivateState = {
+        type: "free",
+        itemIds: ITEM_IDS,
+        carousel: {
+          type: "snapping",
+          transform: { x: -200, y: 0, scale: 1 },
+          lastUpdatedAt: 0,
+          target: { x: -ITEM_WIDTH, y: 0, scale: 1 },
+        },
+        items: {
+          a: makeSettledItem(),
+          b: makeSettledItem(),
+          c: makeSettledItem(),
+        },
+      };
+      const state = reduce(snapping, setConfig(["b", "c"]));
+      expect(state.carousel.type).toBe("snapping");
+      if (state.carousel.type === "snapping") {
+        expect(state.carousel.target.x).toBeCloseTo(0);
+        expect(state.carousel.transform.x).toBeCloseTo(200);
+      }
+    });
+
+    it("drops to free when active item is deleted", () => {
+      const reduce = makeReduce();
+      const state = reduce(makeItemsState(), setConfig(["b", "c"]));
+      expect(state.type).toBe("free");
+    });
+
+    it("stays in items state when active item survives", () => {
+      const reduce = makeReduce();
+      const state = reduce(makeItemsState(), setConfig(["a", "c"]));
+      expect(state.type).toBe("items");
+      if (state.type === "items") {
+        expect(state.activeItemId).toBe("a");
+      }
+    });
+
+    it("updates itemIds in state", () => {
+      const reduce = makeReduce();
+      const state = reduce(free(), setConfig(["b", "c"]));
+      expect(state.itemIds).toEqual(["b", "c"]);
+    });
+
+    it("clamps carousel to new bounds when items shrink", () => {
+      // Settled on last item "c" (index 2, x=-800). After reducing to ["a","b"], max index=1.
+      const reduce = makeReduce();
+      const state = reduce(free(-2 * ITEM_WIDTH), setConfig(["a", "b"]));
+      expect(state.carousel.transform.x).toBeCloseTo(-ITEM_WIDTH);
     });
   });
 

--- a/packages/core/src/model/carousel.ts
+++ b/packages/core/src/model/carousel.ts
@@ -1,6 +1,7 @@
-import type { InterpreterEvent, StoreAction, Model } from "../types.js";
+import type { Model } from "../types.js";
 import {
   type TransformPrivateState,
+  type TransformAction,
   createTransformReduce,
   settleTransform,
 } from "./transform.js";
@@ -29,7 +30,7 @@ export type CarouselPublicState = {
 };
 
 export type CarouselAction =
-  | StoreAction
+  | TransformAction
   | { type: "set-config"; config: CarouselConfig };
 
 // ---------------------------------------------------------------------------
@@ -66,7 +67,7 @@ export type CarouselPrivateState =
       activeItemId: string;
     };
 
-type MotionEvent = Extract<InterpreterEvent, { type: "motion" }>;
+type MotionEvent = Extract<TransformAction, { type: "motion" }>;
 
 // ---------------------------------------------------------------------------
 // Item bounds helper

--- a/packages/core/src/model/carousel.ts
+++ b/packages/core/src/model/carousel.ts
@@ -28,6 +28,10 @@ export type CarouselPublicState = {
   >;
 };
 
+export type CarouselAction =
+  | StoreAction
+  | { type: "set-config"; config: CarouselConfig };
+
 // ---------------------------------------------------------------------------
 // Internal types
 // ---------------------------------------------------------------------------
@@ -44,16 +48,19 @@ export type CarouselPublicState = {
 export type CarouselPrivateState =
   | {
       type: "free";
+      itemIds: readonly string[];
       carousel: TransformPrivateState;
       items: Record<string, TransformPrivateState>;
     }
   | {
       type: "carousel";
+      itemIds: readonly string[];
       carousel: TransformPrivateState;
       items: Record<string, TransformPrivateState>;
     }
   | {
       type: "items";
+      itemIds: readonly string[];
       carousel: TransformPrivateState;
       items: Record<string, TransformPrivateState>;
       activeItemId: string;
@@ -120,13 +127,16 @@ function toCarouselPublicState(
 
 export function createCarouselModel(
   config: CarouselConfig,
-): Model<CarouselPublicState, CarouselPrivateState, StoreAction> {
+): Model<CarouselPublicState, CarouselPrivateState, CarouselAction> {
   const reduce = createCarouselReduce(config);
   return { reduce, publish: toCarouselPublicState };
 }
 
 function createCarouselReduce(config: CarouselConfig) {
   const { itemWidth, itemHeight, itemIds } = config;
+
+  // Mutable item count so the snap-target closure always uses the latest value.
+  let itemCount = itemIds.length;
 
   const itemReduce = createTransformReduce({
     elementWidth: itemWidth,
@@ -140,7 +150,7 @@ function createCarouselReduce(config: CarouselConfig) {
         transform.x,
         velocity.vx,
         itemWidth,
-        itemIds.length,
+        itemCount,
       ),
       y: 0,
       scale: 1,
@@ -195,9 +205,119 @@ function createCarouselReduce(config: CarouselConfig) {
     return changed ? result : items;
   }
 
+  // ---------------------------------------------------------------------------
+  // set-config helpers
+  // ---------------------------------------------------------------------------
+
+  function shiftCarouselTransform(
+    carousel: TransformPrivateState,
+    delta: number,
+    minX: number,
+  ): TransformPrivateState {
+    if (delta === 0) return carousel;
+    switch (carousel.type) {
+      case "snapping": {
+        // Don't clamp the current transform — it's mid-animation and will
+        // converge naturally to the (clamped) target.
+        const newTargetX = Math.max(
+          minX,
+          Math.min(0, carousel.target.x + delta),
+        );
+        return {
+          ...carousel,
+          transform: {
+            ...carousel.transform,
+            x: carousel.transform.x + delta,
+          },
+          target: { ...carousel.target, x: newTargetX },
+        };
+      }
+      default: {
+        const newX = Math.max(minX, Math.min(0, carousel.transform.x + delta));
+        return { ...carousel, transform: { ...carousel.transform, x: newX } };
+      }
+    }
+  }
+
+  function applySetConfig(
+    state: CarouselPrivateState,
+    newConfig: CarouselConfig,
+  ): CarouselPrivateState {
+    const newItemIds = newConfig.itemIds;
+
+    // Find the item the carousel is heading toward in the current list.
+    const carousel = state.carousel;
+    let anchorTargetX: number;
+    if (carousel.type === "snapping") {
+      anchorTargetX = carousel.target.x;
+    } else {
+      const vx =
+        carousel.type === "tracking" || carousel.type === "inertia"
+          ? carousel.velocity.vx
+          : 0;
+      anchorTargetX = computeCarouselSnapTarget(
+        carousel.transform.x,
+        vx,
+        itemWidth,
+        state.itemIds.length,
+      );
+    }
+    const oldAnchorIndex = Math.max(
+      0,
+      Math.min(
+        state.itemIds.length - 1,
+        Math.round(-anchorTargetX / itemWidth),
+      ),
+    );
+    const anchorId = state.itemIds[oldAnchorIndex];
+
+    // Find anchor in new list; fall back to nearest valid index if deleted.
+    let newAnchorIndex = newItemIds.indexOf(anchorId);
+    if (newAnchorIndex < 0) {
+      newAnchorIndex = Math.max(
+        0,
+        Math.min(newItemIds.length - 1, oldAnchorIndex),
+      );
+    }
+
+    const delta = (oldAnchorIndex - newAnchorIndex) * itemWidth;
+    const minX =
+      newItemIds.length > 0 ? -(newItemIds.length - 1) * itemWidth : 0;
+    const newCarousel = shiftCarouselTransform(carousel, delta, minX);
+
+    const newItems: Record<string, TransformPrivateState> = {};
+    for (const id of newItemIds) {
+      newItems[id] = state.items[id] ?? {
+        type: "settled",
+        transform: { x: 0, y: 0, scale: 1 },
+        lastUpdatedAt: NaN,
+      };
+    }
+
+    // Update the mutable count so the snap-target closure stays current.
+    itemCount = newItemIds.length;
+
+    if (state.type === "items" && !newItemIds.includes(state.activeItemId)) {
+      return {
+        type: "free",
+        itemIds: newItemIds,
+        carousel: newCarousel,
+        items: newItems,
+      };
+    }
+
+    return {
+      ...state,
+      itemIds: newItemIds,
+      carousel: newCarousel,
+      items: newItems,
+    };
+  }
+
   return function reduce(
     state: CarouselPrivateState | undefined = {
       type: "free",
+      itemIds,
       carousel: {
         type: "settled",
         transform: { x: 0, y: 0, scale: 1 },
@@ -205,8 +325,12 @@ function createCarouselReduce(config: CarouselConfig) {
       },
       items: makeInitialItems(),
     },
-    action: StoreAction,
+    action: CarouselAction,
   ): CarouselPrivateState {
+    if (action.type === "set-config") {
+      return applySetConfig(state, action.config);
+    }
+
     switch (state.type) {
       case "free": {
         switch (action.type) {
@@ -229,6 +353,7 @@ function createCarouselReduce(config: CarouselConfig) {
                       // Lock to item
                       return {
                         type: "items",
+                        itemIds: state.itemIds,
                         carousel: state.carousel,
                         items: lockItems(state.items, action.itemId, action),
                         activeItemId: action.itemId,
@@ -246,7 +371,12 @@ function createCarouselReduce(config: CarouselConfig) {
               originY: 0,
             };
             const carousel = carouselReduce(state.carousel, normalizedAction);
-            return { type: "carousel", carousel, items: state.items };
+            return {
+              type: "carousel",
+              itemIds: state.itemIds,
+              carousel,
+              items: state.items,
+            };
           }
           case "release":
             return state;
@@ -296,7 +426,12 @@ function createCarouselReduce(config: CarouselConfig) {
           }
           case "release": {
             const carousel = carouselReduce(state.carousel, action);
-            return { type: "free", carousel, items: state.items };
+            return {
+              type: "free",
+              itemIds: state.itemIds,
+              carousel,
+              items: state.items,
+            };
           }
           case "toggle-zoom":
             return state;
@@ -334,7 +469,12 @@ function createCarouselReduce(config: CarouselConfig) {
                 action,
               ),
             };
-            return { type: "free", carousel: state.carousel, items };
+            return {
+              type: "free",
+              itemIds: state.itemIds,
+              carousel: state.carousel,
+              items,
+            };
           }
           case "toggle-zoom": {
             if (action.itemId !== state.activeItemId) return state;

--- a/packages/core/src/model/simple.ts
+++ b/packages/core/src/model/simple.ts
@@ -1,7 +1,8 @@
-import type { State, StoreAction, Model } from "../types.js";
+import type { State, Model } from "../types.js";
 import {
   type TransformPrivateState,
   type TransformConfig,
+  type TransformAction,
   createTransformReduce,
 } from "./transform.js";
 
@@ -17,6 +18,6 @@ function toPublicState(state: TransformPrivateState): State {
 
 export function createModel(
   config?: TransformConfig,
-): Model<State, TransformPrivateState, StoreAction> {
+): Model<State, TransformPrivateState, TransformAction> {
   return { reduce: createTransformReduce(config), publish: toPublicState };
 }

--- a/packages/core/src/model/transform.ts
+++ b/packages/core/src/model/transform.ts
@@ -1,4 +1,6 @@
-import type { StoreAction } from "../types.js";
+import type { InterpreterEvent, StoreAction } from "../types.js";
+
+export type TransformAction = InterpreterEvent | StoreAction;
 import {
   type Transform,
   type TransformVelocity,
@@ -150,7 +152,7 @@ export function createTransformReduce(config?: TransformConfig) {
       transform: { x: 0, y: 0, scale: 1 },
       lastUpdatedAt: NaN,
     },
-    action: StoreAction,
+    action: TransformAction,
   ): TransformPrivateState {
     switch (state.type) {
       case "tracking": {

--- a/packages/core/src/renderer/__tests__/renderer.test.ts
+++ b/packages/core/src/renderer/__tests__/renderer.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
 import { createRenderer } from "../index.js";
-import type { MountedStore, Callback, State } from "../../types.js";
+import type { Store, Callback, State } from "../../types.js";
 
-function makeMockStore(): MountedStore<State> & { emit: (s: State) => void } {
+function makeMockStore(): Store<State> & { emit: (s: State) => void } {
   const callbacks = new Set<Callback<State>>();
   return {
     emit(s: State) {
@@ -13,7 +13,6 @@ function makeMockStore(): MountedStore<State> & { emit: (s: State) => void } {
       return () => callbacks.delete(cb);
     },
     dispatch: vi.fn(),
-    mount: vi.fn(() => vi.fn()),
     unmount: vi.fn(),
   };
 }

--- a/packages/core/src/renderer/__tests__/renderer.test.ts
+++ b/packages/core/src/renderer/__tests__/renderer.test.ts
@@ -12,6 +12,8 @@ function makeMockStore(): MountedStore<State> & { emit: (s: State) => void } {
       callbacks.add(cb);
       return () => callbacks.delete(cb);
     },
+    dispatch: vi.fn(),
+    mount: vi.fn(() => vi.fn()),
     unmount: vi.fn(),
   };
 }

--- a/packages/core/src/renderer/index.ts
+++ b/packages/core/src/renderer/index.ts
@@ -1,12 +1,7 @@
-import type {
-  Renderer,
-  MountedRenderer,
-  MountedStore,
-  State,
-} from "../types.js";
+import type { Renderer, MountedRenderer, Store, State } from "../types.js";
 
 export function createRenderer(): Renderer<State> {
-  return (element: Element, store: MountedStore<State>): MountedRenderer => {
+  return (element: Element, store: Store<State>): MountedRenderer => {
     const el = element as HTMLElement;
 
     const unsubscribe = store.subscribe(({ transformX, transformY, scale }) => {

--- a/packages/core/src/store/__tests__/store.test.ts
+++ b/packages/core/src/store/__tests__/store.test.ts
@@ -191,6 +191,63 @@ describe("createStore", () => {
     store.unmount();
   });
 
+  it("dispatch applies action and resumes the loop", () => {
+    const interp = makeMockInterpreter();
+    const store = createStore(counterModel((s) => s))([interp]);
+    const snapshots: CounterState[] = [];
+    store.subscribe((s) => snapshots.push(s));
+
+    store.dispatch({
+      type: "motion",
+      timestamp: 0,
+      dx: 0,
+      dy: 0,
+      dScale: 1,
+      originX: 0,
+      originY: 0,
+    });
+    flushRaf();
+    expect(snapshots[0].motionCount).toBe(1);
+
+    store.unmount();
+  });
+
+  it("mount subscribes a new interpreter and returns an unmount fn", () => {
+    const store = createStore(counterModel((s) => s))([]);
+    const snapshots: CounterState[] = [];
+    store.subscribe((s) => snapshots.push(s));
+
+    const late = makeMockInterpreter();
+    const unmountLate = store.mount(late);
+
+    late.emit({
+      type: "motion",
+      timestamp: 0,
+      dx: 10,
+      dy: 0,
+      dScale: 1,
+      originX: 0,
+      originY: 0,
+    });
+    flushRaf();
+    expect(snapshots[0].motionCount).toBe(1);
+
+    unmountLate();
+    late.emit({
+      type: "motion",
+      timestamp: 8,
+      dx: 10,
+      dy: 0,
+      dScale: 1,
+      originX: 0,
+      originY: 0,
+    });
+    flushRaf();
+    expect(snapshots[0].motionCount).toBe(1); // still 1, interpreter was unmounted
+
+    store.unmount();
+  });
+
   it("stops notifying after unmount", () => {
     const interp = makeMockInterpreter();
     const store = createStore(counterModel((s) => s))([interp]);

--- a/packages/core/src/store/__tests__/store.test.ts
+++ b/packages/core/src/store/__tests__/store.test.ts
@@ -1,35 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createStore } from "../index.js";
-import type {
-  MountedInterpreter,
-  Callback,
-  InterpreterEvent,
-  StoreAction,
-  Model,
-} from "../../types.js";
+import type { InterpreterEvent, StoreAction, Model } from "../../types.js";
 
-function makeMockInterpreter(): MountedInterpreter & {
-  emit: (event: InterpreterEvent) => void;
-} {
-  const callbacks = new Set<Callback<InterpreterEvent>>();
-  return {
-    emit(event: InterpreterEvent) {
-      for (const cb of callbacks) cb(event);
-    },
-    subscribe(cb: Callback<InterpreterEvent>) {
-      callbacks.add(cb);
-      return () => callbacks.delete(cb);
-    },
-    unmount: vi.fn(),
-  };
-}
-
-// Simple counter state for testing the store in isolation from the model
+// Store tests use a motion-counting model to verify dispatch drives the loop.
 type CounterState = { motionCount: number };
+type CounterAction = InterpreterEvent | StoreAction;
 
 function counterReduce(
   state: CounterState | undefined = { motionCount: 0 },
-  action: StoreAction,
+  action: CounterAction,
 ): CounterState {
   if (action.type === "motion") return { motionCount: state.motionCount + 1 };
   return state;
@@ -37,9 +16,19 @@ function counterReduce(
 
 function counterModel<TPublicState>(
   publish: (s: CounterState) => TPublicState,
-): Model<TPublicState, CounterState> {
+): Model<TPublicState, CounterState, CounterAction> {
   return { reduce: counterReduce, publish };
 }
+
+const motionEvent: InterpreterEvent = {
+  type: "motion",
+  timestamp: 0,
+  dx: 10,
+  dy: 0,
+  dScale: 1,
+  originX: 0,
+  originY: 0,
+};
 
 // Manual rAF control — lets tests trigger animation frames deterministically
 // without depending on fake timer implementation details.
@@ -65,22 +54,20 @@ afterEach(() => {
 
 describe("createStore", () => {
   it("calls reducer with undefined state on initialization", () => {
-    const interp = makeMockInterpreter();
     const firstArgs: Array<CounterState | undefined> = [];
     function spyReduce(
       state: CounterState | undefined,
-      action: StoreAction,
+      action: CounterAction,
     ): CounterState {
       firstArgs.push(state);
       return counterReduce(state, action);
     }
-    createStore({ reduce: spyReduce, publish: (s) => s })([interp]);
+    createStore({ reduce: spyReduce, publish: (s) => s });
     expect(firstArgs[0]).toBeUndefined();
   });
 
   it("notifies subscribers on the first frame with the initial state", () => {
-    const interp = makeMockInterpreter();
-    const store = createStore(counterModel((s) => s))([interp]);
+    const store = createStore(counterModel((s) => s));
     const snapshots: CounterState[] = [];
     store.subscribe((s) => snapshots.push(s));
 
@@ -92,8 +79,7 @@ describe("createStore", () => {
   });
 
   it("pauses the loop when state reference is unchanged after a tick", () => {
-    const interp = makeMockInterpreter();
-    const store = createStore(counterModel((s) => s))([interp]);
+    const store = createStore(counterModel((s) => s));
     const snapshots: CounterState[] = [];
     store.subscribe((s) => snapshots.push(s));
 
@@ -106,24 +92,15 @@ describe("createStore", () => {
     store.unmount();
   });
 
-  it("resumes the loop when an interpreter event changes state", () => {
-    const interp = makeMockInterpreter();
-    const store = createStore(counterModel((s) => s))([interp]);
+  it("resumes the loop when dispatch changes state", () => {
+    const store = createStore(counterModel((s) => s));
     const snapshots: CounterState[] = [];
     store.subscribe((s) => snapshots.push(s));
 
     flushRaf(); // initial state, then pauses
     expect(snapshots.length).toBe(1);
 
-    interp.emit({
-      type: "motion",
-      timestamp: 0,
-      dx: 10,
-      dy: 0,
-      dScale: 1,
-      originX: 0,
-      originY: 0,
-    });
+    store.dispatch(motionEvent);
     flushRaf(); // loop resumed, new state emitted
     expect(snapshots.length).toBe(2);
     expect(snapshots[1].motionCount).toBe(1);
@@ -134,30 +111,13 @@ describe("createStore", () => {
     store.unmount();
   });
 
-  it("forwards interpreter events to the reducer before the next frame", () => {
-    const interp = makeMockInterpreter();
-    const store = createStore(counterModel((s) => s))([interp]);
+  it("batches multiple dispatches before the next frame", () => {
+    const store = createStore(counterModel((s) => s));
     const snapshots: CounterState[] = [];
     store.subscribe((s) => snapshots.push(s));
 
-    interp.emit({
-      type: "motion",
-      timestamp: 0,
-      dx: 50,
-      dy: 30,
-      dScale: 1,
-      originX: 0,
-      originY: 0,
-    });
-    interp.emit({
-      type: "motion",
-      timestamp: 8,
-      dx: 10,
-      dy: 0,
-      dScale: 1,
-      originX: 0,
-      originY: 0,
-    });
+    store.dispatch(motionEvent);
+    store.dispatch(motionEvent);
 
     flushRaf();
 
@@ -167,23 +127,14 @@ describe("createStore", () => {
   });
 
   it("applies publish before notifying subscribers", () => {
-    const interp = makeMockInterpreter();
     const store = createStore(
       counterModel((state) => ({ doubled: state.motionCount * 2 })),
-    )([interp]);
+    );
 
     const snapshots: { doubled: number }[] = [];
     store.subscribe((s) => snapshots.push(s));
 
-    interp.emit({
-      type: "motion",
-      timestamp: 0,
-      dx: 10,
-      dy: 0,
-      dScale: 1,
-      originX: 0,
-      originY: 0,
-    });
+    store.dispatch(motionEvent);
     flushRaf();
 
     expect(snapshots[0].doubled).toBe(2);
@@ -191,79 +142,13 @@ describe("createStore", () => {
     store.unmount();
   });
 
-  it("dispatch applies action and resumes the loop", () => {
-    const interp = makeMockInterpreter();
-    const store = createStore(counterModel((s) => s))([interp]);
-    const snapshots: CounterState[] = [];
-    store.subscribe((s) => snapshots.push(s));
-
-    store.dispatch({
-      type: "motion",
-      timestamp: 0,
-      dx: 0,
-      dy: 0,
-      dScale: 1,
-      originX: 0,
-      originY: 0,
-    });
-    flushRaf();
-    expect(snapshots[0].motionCount).toBe(1);
-
-    store.unmount();
-  });
-
-  it("mount subscribes a new interpreter and returns an unmount fn", () => {
-    const store = createStore(counterModel((s) => s))([]);
-    const snapshots: CounterState[] = [];
-    store.subscribe((s) => snapshots.push(s));
-
-    const late = makeMockInterpreter();
-    const unmountLate = store.mount(late);
-
-    late.emit({
-      type: "motion",
-      timestamp: 0,
-      dx: 10,
-      dy: 0,
-      dScale: 1,
-      originX: 0,
-      originY: 0,
-    });
-    flushRaf();
-    expect(snapshots[0].motionCount).toBe(1);
-
-    unmountLate();
-    late.emit({
-      type: "motion",
-      timestamp: 8,
-      dx: 10,
-      dy: 0,
-      dScale: 1,
-      originX: 0,
-      originY: 0,
-    });
-    flushRaf();
-    expect(snapshots[0].motionCount).toBe(1); // still 1, interpreter was unmounted
-
-    store.unmount();
-  });
-
   it("stops notifying after unmount", () => {
-    const interp = makeMockInterpreter();
-    const store = createStore(counterModel((s) => s))([interp]);
+    const store = createStore(counterModel((s) => s));
     const snapshots: CounterState[] = [];
     store.subscribe((s) => snapshots.push(s));
 
     store.unmount();
-    interp.emit({
-      type: "motion",
-      timestamp: 0,
-      dx: 50,
-      dy: 0,
-      dScale: 1,
-      originX: 0,
-      originY: 0,
-    });
+    store.dispatch(motionEvent);
     flushRaf();
 
     expect(snapshots).toHaveLength(0);

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -1,81 +1,56 @@
 import type {
   Store,
-  MountedStore,
-  MountedInterpreter,
   Callback,
   UnsubscribeFn,
-  UnmountFn,
   Model,
   StoreAction,
 } from "../types.js";
 
-export function createStore<TPrivateState, TState, TAction = StoreAction>(
-  model: Model<TState, TPrivateState, TAction>,
-): Store<TState, TAction> {
-  return (
-    interpreters: MountedInterpreter[],
-  ): MountedStore<TState, TAction> => {
-    const callbacks = new Set<Callback<TState>>();
+export function createStore<TPrivateState, TState, TExtraAction = never>(
+  model: Model<TState, TPrivateState, StoreAction | TExtraAction>,
+): Store<TState, StoreAction | TExtraAction> {
+  const callbacks = new Set<Callback<TState>>();
 
-    let state = model.reduce(undefined, {
-      type: "tick",
-      timestamp: 0,
-    } as unknown as TAction);
-    let lastEmittedState: TPrivateState | undefined;
+  let state = model.reduce(undefined, { type: "tick", timestamp: 0 });
+  let lastEmittedState: TPrivateState | undefined;
 
-    let rafId: number | null = null;
-    let mounted = true;
+  let rafId: number | null = null;
+  let mounted = true;
 
-    function loop(timestamp: number) {
-      if (!mounted) return;
-      state = model.reduce(state, {
-        type: "tick",
-        timestamp,
-      } as unknown as TAction);
-      if (state === lastEmittedState) {
-        rafId = null;
-        return;
-      }
-      lastEmittedState = state;
-      const publicState = model.publish(state);
-      for (const cb of callbacks) cb(publicState);
+  function loop(timestamp: number) {
+    if (!mounted) return;
+    state = model.reduce(state, { type: "tick", timestamp });
+    if (state === lastEmittedState) {
+      rafId = null;
+      return;
+    }
+    lastEmittedState = state;
+    const publicState = model.publish(state);
+    for (const cb of callbacks) cb(publicState);
+    rafId = requestAnimationFrame(loop);
+  }
+
+  function resumeLoop() {
+    if (rafId === null && mounted) {
       rafId = requestAnimationFrame(loop);
     }
+  }
 
-    function resumeLoop() {
-      if (rafId === null && mounted) {
-        rafId = requestAnimationFrame(loop);
-      }
-    }
+  rafId = requestAnimationFrame(loop);
 
-    function dispatch(action: TAction) {
+  return {
+    subscribe(cb: Callback<TState>): UnsubscribeFn {
+      callbacks.add(cb);
+      return () => callbacks.delete(cb);
+    },
+    dispatch(action: StoreAction | TExtraAction) {
       state = model.reduce(state, action);
       resumeLoop();
-    }
-
-    function mount(interp: MountedInterpreter): UnmountFn {
-      return interp.subscribe((event) => {
-        dispatch(event as unknown as TAction);
-      });
-    }
-
-    const unsubscribers: UnsubscribeFn[] = interpreters.map(mount);
-
-    rafId = requestAnimationFrame(loop);
-
-    return {
-      subscribe(cb: Callback<TState>): UnsubscribeFn {
-        callbacks.add(cb);
-        return () => callbacks.delete(cb);
-      },
-      dispatch,
-      mount,
-      unmount() {
-        mounted = false;
-        if (rafId !== null) cancelAnimationFrame(rafId);
-        for (const unsub of unsubscribers) unsub();
-        callbacks.clear();
-      },
-    };
+    },
+    unmount() {
+      mounted = false;
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      callbacks.clear();
+    },
   };
 }

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -4,16 +4,23 @@ import type {
   MountedInterpreter,
   Callback,
   UnsubscribeFn,
+  UnmountFn,
   Model,
+  StoreAction,
 } from "../types.js";
 
-export function createStore<TPrivateState, TState>(
-  model: Model<TState, TPrivateState>,
-): Store<TState> {
-  return (interpreters: MountedInterpreter[]): MountedStore<TState> => {
+export function createStore<TPrivateState, TState, TAction = StoreAction>(
+  model: Model<TState, TPrivateState, TAction>,
+): Store<TState, TAction> {
+  return (
+    interpreters: MountedInterpreter[],
+  ): MountedStore<TState, TAction> => {
     const callbacks = new Set<Callback<TState>>();
 
-    let state = model.reduce(undefined, { type: "tick", timestamp: 0 });
+    let state = model.reduce(undefined, {
+      type: "tick",
+      timestamp: 0,
+    } as unknown as TAction);
     let lastEmittedState: TPrivateState | undefined;
 
     let rafId: number | null = null;
@@ -21,7 +28,10 @@ export function createStore<TPrivateState, TState>(
 
     function loop(timestamp: number) {
       if (!mounted) return;
-      state = model.reduce(state, { type: "tick", timestamp });
+      state = model.reduce(state, {
+        type: "tick",
+        timestamp,
+      } as unknown as TAction);
       if (state === lastEmittedState) {
         rafId = null;
         return;
@@ -38,15 +48,19 @@ export function createStore<TPrivateState, TState>(
       }
     }
 
-    // Subscribe to all interpreters
-    const unsubscribers = interpreters.map((interp) =>
-      interp.subscribe((event) => {
-        state = model.reduce(state, event);
-        resumeLoop();
-      }),
-    );
+    function dispatch(action: TAction) {
+      state = model.reduce(state, action);
+      resumeLoop();
+    }
 
-    // Start the loop
+    function mount(interp: MountedInterpreter): UnmountFn {
+      return interp.subscribe((event) => {
+        dispatch(event as unknown as TAction);
+      });
+    }
+
+    const unsubscribers: UnsubscribeFn[] = interpreters.map(mount);
+
     rafId = requestAnimationFrame(loop);
 
     return {
@@ -54,6 +68,8 @@ export function createStore<TPrivateState, TState>(
         callbacks.add(cb);
         return () => callbacks.delete(cb);
       },
+      dispatch,
+      mount,
       unmount() {
         mounted = false;
         if (rafId !== null) cancelAnimationFrame(rafId);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -43,14 +43,16 @@ export type MountedInterpreter = {
 
 export type Interpreter = (element: Element) => MountedInterpreter;
 
-export type MountedStore<TState> = {
+export type MountedStore<TState, TAction = StoreAction> = {
   subscribe: (cb: Callback<TState>) => UnsubscribeFn;
+  dispatch: (action: TAction) => void;
+  mount: (interpreter: MountedInterpreter) => UnmountFn;
   unmount: UnmountFn;
 };
 
-export type Store<TState> = (
+export type Store<TState, TAction = StoreAction> = (
   interpreters: MountedInterpreter[],
-) => MountedStore<TState>;
+) => MountedStore<TState, TAction>;
 
 export type StoreAction =
   | InterpreterEvent

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -43,20 +43,13 @@ export type MountedInterpreter = {
 
 export type Interpreter = (element: Element) => MountedInterpreter;
 
-export type MountedStore<TState, TAction = StoreAction> = {
+export type Store<TState, TAction = StoreAction> = {
   subscribe: (cb: Callback<TState>) => UnsubscribeFn;
   dispatch: (action: TAction) => void;
-  mount: (interpreter: MountedInterpreter) => UnmountFn;
   unmount: UnmountFn;
 };
 
-export type Store<TState, TAction = StoreAction> = (
-  interpreters: MountedInterpreter[],
-) => MountedStore<TState, TAction>;
-
-export type StoreAction =
-  | InterpreterEvent
-  | { type: "tick"; timestamp: number };
+export type StoreAction = { type: "tick"; timestamp: number };
 
 /**
  * A pure function that computes the next private state from the current state and an action.
@@ -81,5 +74,5 @@ export type MountedRenderer = {
 
 export type Renderer<TState> = (
   element: Element,
-  store: MountedStore<TState>,
+  store: Store<TState>,
 ) => MountedRenderer;

--- a/packages/demo/src/App.tsx
+++ b/packages/demo/src/App.tsx
@@ -1,7 +1,10 @@
 import { useState } from "react";
 import { PinchPanContainer } from "./PinchPanContainer.js";
 import { CarouselContainer } from "./CarouselContainer.js";
-import { ScalableCarouselContainer } from "./ScalableCarouselContainer.js";
+import {
+  ScalableCarouselContainer,
+  ScalableCarouselItem,
+} from "./ScalableCarouselContainer.js";
 
 const IMAGE_URL = "https://picsum.photos/id/599/400/300";
 
@@ -95,9 +98,11 @@ export function App() {
       {tab === "scalable-carousel" && (
         <div className="flex-1 flex flex-col justify-center bg-gray-900">
           <ScalableCarouselContainer
-            items={SCALABLE_CAROUSEL_ITEMS.map(({ id, photoId }) => ({
-              id,
-              children: (
+            itemWidth={SCALABLE_CAROUSEL_ITEM_WIDTH}
+            itemHeight={SCALABLE_CAROUSEL_ITEM_HEIGHT}
+          >
+            {SCALABLE_CAROUSEL_ITEMS.map(({ id, photoId }) => (
+              <ScalableCarouselItem key={id} id={id}>
                 <img
                   src={`https://picsum.photos/id/${photoId}/${SCALABLE_CAROUSEL_ITEM_WIDTH}/${SCALABLE_CAROUSEL_ITEM_HEIGHT}`}
                   alt={id}
@@ -110,11 +115,9 @@ export function App() {
                     userSelect: "none",
                   }}
                 />
-              ),
-            }))}
-            itemWidth={SCALABLE_CAROUSEL_ITEM_WIDTH}
-            itemHeight={SCALABLE_CAROUSEL_ITEM_HEIGHT}
-          />
+              </ScalableCarouselItem>
+            ))}
+          </ScalableCarouselContainer>
           <p className="text-center text-gray-500 text-sm py-2">
             Drag or swipe to navigate · Pinch to zoom · Snaps back on release
           </p>

--- a/packages/demo/src/CarouselContainer.tsx
+++ b/packages/demo/src/CarouselContainer.tsx
@@ -46,11 +46,15 @@ export function CarouselContainer({
           scale,
         }),
       }),
-    )(interpreters);
+    );
+    const stops = interpreters.map((i) =>
+      i.subscribe((e) => store.dispatch(e)),
+    );
     const renderer = createRenderer()(content, store);
 
     return () => {
       renderer.unmount();
+      for (const stop of stops) stop();
       store.unmount();
       for (const interp of interpreters) interp.unmount();
     };

--- a/packages/demo/src/PinchPanContainer.tsx
+++ b/packages/demo/src/PinchPanContainer.tsx
@@ -28,11 +28,15 @@ export function PinchPanContainer({ children, className }: Props) {
       mouseWheelInterpreter()(container),
     ];
 
-    const store = createStore(createModel())(interpreters);
+    const store = createStore(createModel());
+    const stops = interpreters.map((i) =>
+      i.subscribe((e) => store.dispatch(e)),
+    );
     const renderer = createRenderer()(content, store);
 
     return () => {
       renderer.unmount();
+      for (const stop of stops) stop();
       store.unmount();
       for (const interp of interpreters) interp.unmount();
     };

--- a/packages/demo/src/ScalableCarouselContainer.tsx
+++ b/packages/demo/src/ScalableCarouselContainer.tsx
@@ -14,9 +14,8 @@ import {
   mouseDragInterpreter,
   createStore,
   createCarouselModel,
-  type MountedStore,
+  type Store,
   type MountedInterpreter,
-  type InterpreterEvent,
   mouseWheelInterpreter,
   doubleTapInterpreter,
   type CarouselAction,
@@ -28,7 +27,7 @@ import {
 // ---------------------------------------------------------------------------
 
 type CarouselContextValue = {
-  store: MountedStore<CarouselPublicState, CarouselAction>;
+  store: Store<CarouselPublicState, CarouselAction>;
   itemWidth: number;
   itemHeight: number;
 };
@@ -45,9 +44,7 @@ function withItemId(
 ): MountedInterpreter {
   return {
     subscribe(cb) {
-      return interp.subscribe((event: InterpreterEvent) =>
-        cb({ ...event, itemId }),
-      );
+      return interp.subscribe((event) => cb({ ...event, itemId }));
     },
     unmount: () => interp.unmount(),
   };
@@ -84,7 +81,9 @@ export function ScalableCarouselItem({
       withItemId(doubleTapInterpreter()(viewport), id),
     ];
 
-    const unmounts = interpreters.map((interp) => store.mount(interp));
+    const unmounts = interpreters.map((interp) =>
+      interp.subscribe((e) => store.dispatch(e)),
+    );
     return () => {
       for (const unmount of unmounts) unmount();
       for (const interp of interpreters) interp.unmount();
@@ -150,7 +149,7 @@ export function ScalableCarouselContainer({
   className,
 }: Props) {
   const stripRef = useRef<HTMLDivElement>(null);
-  const [store, setStore] = useState<MountedStore<
+  const [store, setStore] = useState<Store<
     CarouselPublicState,
     CarouselAction
   > | null>(null);
@@ -173,7 +172,7 @@ export function ScalableCarouselContainer({
         itemHeight,
         itemIds: itemIdsRef.current,
       }),
-    )([]);
+    );
 
     setStore(s);
 

--- a/packages/demo/src/ScalableCarouselContainer.tsx
+++ b/packages/demo/src/ScalableCarouselContainer.tsx
@@ -1,26 +1,43 @@
-import { useEffect, useRef, type ReactNode } from "react";
+import {
+  Children,
+  createContext,
+  isValidElement,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import {
   touchInterpreter,
   mouseDragInterpreter,
   createStore,
   createCarouselModel,
+  type MountedStore,
   type MountedInterpreter,
   type InterpreterEvent,
   mouseWheelInterpreter,
   doubleTapInterpreter,
+  type CarouselAction,
+  type CarouselPublicState,
 } from "@mimosa/core";
 
-type ScalableCarouselItem = {
-  id: string;
-  children: ReactNode;
-};
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
 
-type Props = {
-  items: ScalableCarouselItem[];
+type CarouselContextValue = {
+  store: MountedStore<CarouselPublicState, CarouselAction>;
   itemWidth: number;
   itemHeight: number;
-  className?: string;
 };
+
+const CarouselContext = createContext<CarouselContextValue | null>(null);
+
+// ---------------------------------------------------------------------------
+// withItemId — tags all events from an interpreter with an item ID
+// ---------------------------------------------------------------------------
 
 function withItemId(
   interp: MountedInterpreter,
@@ -36,57 +53,159 @@ function withItemId(
   };
 }
 
+// ---------------------------------------------------------------------------
+// ScalableCarouselItem
+// ---------------------------------------------------------------------------
+
+type ScalableCarouselItemProps = {
+  id: string;
+  children?: ReactNode;
+};
+
+export function ScalableCarouselItem({
+  id,
+  children,
+}: ScalableCarouselItemProps) {
+  const ctx = useContext(CarouselContext);
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  // Mount interpreters for this item.
+  useEffect(() => {
+    if (!ctx) return;
+    const { store } = ctx;
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+
+    const interpreters: MountedInterpreter[] = [
+      withItemId(touchInterpreter()(viewport), id),
+      withItemId(mouseDragInterpreter()(viewport), id),
+      withItemId(mouseWheelInterpreter()(viewport), id),
+      withItemId(doubleTapInterpreter()(viewport), id),
+    ];
+
+    const unmounts = interpreters.map((interp) => store.mount(interp));
+    return () => {
+      for (const unmount of unmounts) unmount();
+      for (const interp of interpreters) interp.unmount();
+    };
+  }, [ctx, id]);
+
+  // Subscribe to store and apply this item's transform.
+  useEffect(() => {
+    if (!ctx) return;
+    return ctx.store.subscribe((state) => {
+      const el = contentRef.current;
+      const itemState = state.items[id];
+      if (el && itemState) {
+        el.style.transform = `translate(${itemState.transformX}px, ${itemState.transformY}px) scale(${itemState.scale})`;
+        el.style.transformOrigin = "0 0";
+      }
+    });
+  }, [ctx, id]);
+
+  return (
+    <div
+      ref={viewportRef}
+      style={{
+        width: ctx?.itemWidth ?? 0,
+        height: ctx?.itemHeight ?? 0,
+        flexShrink: 0,
+        overflow: "hidden",
+        cursor: "grab",
+      }}
+    >
+      <div ref={contentRef} style={{ width: "100%", height: "100%" }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ScalableCarouselContainer
+// ---------------------------------------------------------------------------
+
+type Props = {
+  children?: ReactNode;
+  itemWidth: number;
+  itemHeight: number;
+  className?: string;
+};
+
+function deriveItemIds(children: ReactNode): readonly string[] {
+  return Children.toArray(children)
+    .filter(
+      (child): child is React.ReactElement<ScalableCarouselItemProps> =>
+        isValidElement(child) &&
+        (child.type as unknown) === ScalableCarouselItem,
+    )
+    .map((child) => child.props.id);
+}
+
 export function ScalableCarouselContainer({
-  items,
+  children,
   itemWidth,
   itemHeight,
   className,
 }: Props) {
   const stripRef = useRef<HTMLDivElement>(null);
-  const itemContentRefs = useRef<Map<string, HTMLDivElement>>(new Map());
-  const itemViewportRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  const [store, setStore] = useState<MountedStore<
+    CarouselPublicState,
+    CarouselAction
+  > | null>(null);
 
+  // Keep a ref to the latest itemIds so effects can read the current value
+  // without needing it in their dependency arrays (the array is a new reference
+  // every render even when content is unchanged).
+  const itemIds = deriveItemIds(children);
+  const itemIdsRef = useRef<readonly string[]>(itemIds);
+  itemIdsRef.current = itemIds;
+
+  // Stable string key used as a dep to detect actual content changes.
+  const itemIdsKey = itemIds.join(",");
+
+  // Create the store once per itemWidth/itemHeight.
   useEffect(() => {
-    const strip = stripRef.current;
-    if (!strip) return;
-
-    const allInterpreters: MountedInterpreter[] = [];
-    for (const item of items) {
-      const viewport = itemViewportRefs.current.get(item.id);
-      if (!viewport) continue;
-      allInterpreters.push(
-        withItemId(touchInterpreter()(viewport), item.id),
-        withItemId(mouseDragInterpreter()(viewport), item.id),
-        withItemId(mouseWheelInterpreter()(viewport), item.id),
-        withItemId(doubleTapInterpreter()(viewport), item.id),
-      );
-    }
-
-    const store = createStore(
+    const s = createStore(
       createCarouselModel({
         itemWidth,
         itemHeight,
-        itemIds: items.map((i) => i.id),
+        itemIds: itemIdsRef.current,
       }),
-    )(allInterpreters);
+    )([]);
 
-    const unsubscribe = store.subscribe((state) => {
-      strip.style.transform = `translateX(${state.carouselTranslateX}px)`;
-      for (const [id, itemState] of Object.entries(state.items)) {
-        const el = itemContentRefs.current.get(id);
-        if (el) {
-          el.style.transform = `translate(${itemState.transformX}px, ${itemState.transformY}px) scale(${itemState.scale})`;
-          el.style.transformOrigin = "0 0";
-        }
+    setStore(s);
+
+    const unsubscribe = s.subscribe((state) => {
+      if (stripRef.current) {
+        stripRef.current.style.transform = `translateX(${state.carouselTranslateX}px)`;
       }
     });
 
     return () => {
       unsubscribe();
-      store.unmount();
-      for (const interp of allInterpreters) interp.unmount();
+      s.unmount();
+      setStore(null);
     };
-  }, [items, itemWidth, itemHeight]);
+  }, [itemWidth, itemHeight]);
+
+  // Dispatch set-config whenever the item list changes after the store is ready.
+  // itemIdsKey is included as a trigger dep even though itemIdsRef.current is
+  // what's read inside — the ref is always current, the key signals the change.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: itemIdsKey is an intentional trigger dep for itemIdsRef.current
+  useEffect(() => {
+    if (!store) return;
+    store.dispatch({
+      type: "set-config",
+      config: { itemWidth, itemHeight, itemIds: itemIdsRef.current },
+    });
+  }, [store, itemWidth, itemHeight, itemIdsKey]);
+
+  const contextValue = useMemo(
+    () => (store ? { store, itemWidth, itemHeight } : null),
+    [store, itemWidth, itemHeight],
+  );
 
   return (
     <div
@@ -94,30 +213,9 @@ export function ScalableCarouselContainer({
       style={{ overflow: "hidden", touchAction: "none" }}
     >
       <div ref={stripRef} style={{ display: "flex" }}>
-        {items.map((item) => (
-          <div
-            key={item.id}
-            ref={(el) => {
-              if (el) itemViewportRefs.current.set(item.id, el);
-            }}
-            style={{
-              width: itemWidth,
-              height: itemHeight,
-              flexShrink: 0,
-              overflow: "hidden",
-              cursor: "grab",
-            }}
-          >
-            <div
-              ref={(el) => {
-                if (el) itemContentRefs.current.set(item.id, el);
-              }}
-              style={{ width: "100%", height: "100%" }}
-            >
-              {item.children}
-            </div>
-          </div>
-        ))}
+        <CarouselContext.Provider value={contextValue}>
+          {children}
+        </CarouselContext.Provider>
       </div>
     </div>
   );


### PR DESCRIPTION
Enhancements

* The scalable carousel reducer now takes the `set-config` action which updates item ids array.

API Changes

* Store no longer takes interpreters as an argument. Components that depend on Store now wire interpreters manually using the newly added `dispatch` method.