### PR TITLE
Add @mimosa/react package

### DIFF
--- a/design/01_technology_stack.md
+++ b/design/01_technology_stack.md
@@ -6,7 +6,8 @@ This project uses a monorepo structure to manage the library and the demo applic
 
 | Package | Role |
 |---------|------|
-| `@mimosa/core` | Library |
+| `@mimosa/core` | Framework-agnostic gesture library |
+| `@mimosa/react` | React component wrappers around `@mimosa/core` |
 | `@mimosa/demo` | Demo application for manual testing |
 
 ## Directory Structure
@@ -34,6 +35,14 @@ packages/
       types.ts           # InterpreterEvent, State, and common primitive types
     package.json
     tsconfig.json
+  react/                 # @mimosa/react
+    src/
+      PinchPanContainer.tsx
+      CarouselContainer.tsx
+      ScalableCarouselContainer.tsx
+      index.ts
+    package.json
+    tsconfig.json
   demo/                  # @mimosa/demo
     src/
     package.json
@@ -48,6 +57,8 @@ package.json             # workspace root
   - Vite
 - `@mimosa/core`
   - Vitest
+- `@mimosa/react`
+  - React (peer dependency)
 - `@mimosa/demo`
   - React
   - Tailwind CSS

--- a/package-lock.json
+++ b/package-lock.json
@@ -1068,6 +1068,10 @@
       "resolved": "packages/demo",
       "link": true
     },
+    "node_modules/@mimosa/react": {
+      "resolved": "packages/react",
+      "link": true
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4413,6 +4417,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@mimosa/core": "*",
+        "@mimosa/react": "*",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -4425,6 +4430,20 @@
         "tailwindcss": "^3.4.3",
         "typescript": "^5.4.5",
         "vite": "^5.2.11"
+      }
+    },
+    "packages/react": {
+      "name": "@mimosa/react",
+      "version": "0.1.0",
+      "dependencies": {
+        "@mimosa/core": "*"
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.3",
+        "typescript": "^5.4.5"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "packages/*"
   ],
   "scripts": {
-    "tsc": "npm run tsc --workspace=packages/core",
+    "tsc": "npm run tsc --workspace=packages/core && npm run tsc --workspace=packages/react",
     "build": "npm run build --workspaces",
     "test": "npm run test --workspace=packages/core",
     "dev": "npm run dev --workspace=packages/demo",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,7 @@ export { createRenderer } from "./renderer/index.js";
 export {
   createModel,
   createCarouselModel,
+  type TransformConfig,
   type CarouselConfig,
   type CarouselPublicState,
   type CarouselAction,

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@mimosa/core": "*",
+    "@mimosa/react": "*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/packages/demo/src/App.tsx
+++ b/packages/demo/src/App.tsx
@@ -1,10 +1,16 @@
 import { useState } from "react";
-import { PinchPanContainer } from "./PinchPanContainer.js";
-import { CarouselContainer } from "./CarouselContainer.js";
 import {
+  touchInterpreter,
+  mouseDragInterpreter,
+  mouseWheelInterpreter,
+  doubleTapInterpreter,
+} from "@mimosa/core";
+import {
+  PinchPanContainer,
+  CarouselContainer,
   ScalableCarouselContainer,
   ScalableCarouselItem,
-} from "./ScalableCarouselContainer.js";
+} from "@mimosa/react";
 
 const IMAGE_URL = "https://picsum.photos/id/599/400/300";
 
@@ -25,6 +31,21 @@ const SCALABLE_CAROUSEL_ITEMS = [
   { id: "photo-3", photoId: "30" },
   { id: "photo-4", photoId: "40" },
   { id: "photo-5", photoId: "50" },
+];
+
+const pinchPanInterpreters = [
+  touchInterpreter(),
+  mouseDragInterpreter(),
+  mouseWheelInterpreter(),
+];
+
+const carouselInterpreters = [touchInterpreter(), mouseDragInterpreter()];
+
+const scalableItemInterpreters = [
+  touchInterpreter(),
+  mouseDragInterpreter(),
+  mouseWheelInterpreter(),
+  doubleTapInterpreter(),
 ];
 
 type Tab = "pinch-pan" | "carousel" | "scalable-carousel";
@@ -62,7 +83,10 @@ export function App() {
       </header>
 
       {tab === "pinch-pan" && (
-        <PinchPanContainer className="flex-1 w-full">
+        <PinchPanContainer
+          className="flex-1 w-full"
+          interpreters={pinchPanInterpreters}
+        >
           <img
             src={IMAGE_URL}
             alt="demo"
@@ -78,6 +102,7 @@ export function App() {
             itemCount={CAROUSEL_ITEMS.length}
             itemWidth={400}
             className="flex-1"
+            interpreters={carouselInterpreters}
           >
             {CAROUSEL_ITEMS.map(({ label, bg }) => (
               <div
@@ -102,7 +127,11 @@ export function App() {
             itemHeight={SCALABLE_CAROUSEL_ITEM_HEIGHT}
           >
             {SCALABLE_CAROUSEL_ITEMS.map(({ id, photoId }) => (
-              <ScalableCarouselItem key={id} id={id}>
+              <ScalableCarouselItem
+                key={id}
+                id={id}
+                interpreters={scalableItemInterpreters}
+              >
                 <img
                   src={`https://picsum.photos/id/${photoId}/${SCALABLE_CAROUSEL_ITEM_WIDTH}/${SCALABLE_CAROUSEL_ITEM_HEIGHT}`}
                   alt={id}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@mimosa/react",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "tsc": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0"
+  },
+  "dependencies": {
+    "@mimosa/core": "*"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "typescript": "^5.4.5"
+  }
+}

--- a/packages/react/src/CarouselContainer.tsx
+++ b/packages/react/src/CarouselContainer.tsx
@@ -1,17 +1,21 @@
 import { useEffect, useRef, type ReactNode } from "react";
 import {
-  touchInterpreter,
-  mouseDragInterpreter,
   createStore,
   createRenderer,
   createModel,
+  type Interpreter,
+  type TransformConfig,
 } from "@mimosa/core";
 
 type Props = {
-  children: ReactNode;
+  children?: ReactNode;
   itemCount: number;
   itemWidth: number;
   className?: string;
+  // Frozen at mount. To swap interpreters, remount via a key change.
+  interpreters: Interpreter[];
+  // snapTarget in modelOptions overrides the default page-snap behaviour.
+  modelOptions?: TransformConfig;
 };
 
 export function CarouselContainer({
@@ -19,9 +23,14 @@ export function CarouselContainer({
   itemCount,
   itemWidth,
   className,
+  interpreters,
+  modelOptions,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+  const interpretersRef = useRef(interpreters);
+  const modelOptionsRef = useRef(modelOptions);
+  modelOptionsRef.current = modelOptions;
 
   useEffect(() => {
     const container = containerRef.current;
@@ -34,10 +43,7 @@ export function CarouselContainer({
       return -clamped * itemWidth;
     };
 
-    const interpreters = [
-      touchInterpreter()(container),
-      mouseDragInterpreter()(container),
-    ];
+    const mounted = interpretersRef.current.map((interp) => interp(container));
     const store = createStore(
       createModel({
         snapTarget: ({ transform: { x, y, scale } }) => ({
@@ -45,18 +51,17 @@ export function CarouselContainer({
           y,
           scale,
         }),
+        ...modelOptionsRef.current,
       }),
     );
-    const stops = interpreters.map((i) =>
-      i.subscribe((e) => store.dispatch(e)),
-    );
+    const stops = mounted.map((m) => m.subscribe((e) => store.dispatch(e)));
     const renderer = createRenderer()(content, store);
 
     return () => {
       renderer.unmount();
       for (const stop of stops) stop();
       store.unmount();
-      for (const interp of interpreters) interp.unmount();
+      for (const m of mounted) m.unmount();
     };
   }, [itemCount, itemWidth]);
 

--- a/packages/react/src/PinchPanContainer.tsx
+++ b/packages/react/src/PinchPanContainer.tsx
@@ -1,44 +1,46 @@
 import { useEffect, useRef, type ReactNode } from "react";
 import {
-  touchInterpreter,
-  mouseDragInterpreter,
-  mouseWheelInterpreter,
   createStore,
   createRenderer,
   createModel,
+  type Interpreter,
+  type TransformConfig,
 } from "@mimosa/core";
 
 type Props = {
-  children: ReactNode;
+  children?: ReactNode;
   className?: string;
+  // Frozen at mount. To swap interpreters, remount via a key change.
+  interpreters: Interpreter[];
+  modelOptions?: TransformConfig;
 };
 
-export function PinchPanContainer({ children, className }: Props) {
+export function PinchPanContainer({
+  children,
+  className,
+  interpreters,
+  modelOptions,
+}: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+  const interpretersRef = useRef(interpreters);
+  const modelOptionsRef = useRef(modelOptions);
 
   useEffect(() => {
     const container = containerRef.current;
     const content = contentRef.current;
     if (!container || !content) return;
 
-    const interpreters = [
-      touchInterpreter()(container),
-      mouseDragInterpreter()(container),
-      mouseWheelInterpreter()(container),
-    ];
-
-    const store = createStore(createModel());
-    const stops = interpreters.map((i) =>
-      i.subscribe((e) => store.dispatch(e)),
-    );
+    const mounted = interpretersRef.current.map((interp) => interp(container));
+    const store = createStore(createModel(modelOptionsRef.current));
+    const stops = mounted.map((m) => m.subscribe((e) => store.dispatch(e)));
     const renderer = createRenderer()(content, store);
 
     return () => {
       renderer.unmount();
       for (const stop of stops) stop();
       store.unmount();
-      for (const interp of interpreters) interp.unmount();
+      for (const m of mounted) m.unmount();
     };
   }, []);
 

--- a/packages/react/src/ScalableCarouselContainer.tsx
+++ b/packages/react/src/ScalableCarouselContainer.tsx
@@ -10,16 +10,13 @@ import {
   type ReactNode,
 } from "react";
 import {
-  touchInterpreter,
-  mouseDragInterpreter,
   createStore,
   createCarouselModel,
   type Store,
   type MountedInterpreter,
-  mouseWheelInterpreter,
-  doubleTapInterpreter,
   type CarouselAction,
   type CarouselPublicState,
+  type Interpreter,
 } from "@mimosa/core";
 
 // ---------------------------------------------------------------------------
@@ -35,7 +32,7 @@ type CarouselContextValue = {
 const CarouselContext = createContext<CarouselContextValue | null>(null);
 
 // ---------------------------------------------------------------------------
-// withItemId — tags all events from an interpreter with an item ID
+// withItemId — tags all events from a mounted interpreter with an item ID
 // ---------------------------------------------------------------------------
 
 function withItemId(
@@ -57,40 +54,37 @@ function withItemId(
 type ScalableCarouselItemProps = {
   id: string;
   children?: ReactNode;
+  // Frozen at mount. To swap interpreters, remount via a key change.
+  interpreters: Interpreter[];
 };
 
 export function ScalableCarouselItem({
   id,
   children,
+  interpreters,
 }: ScalableCarouselItemProps) {
   const ctx = useContext(CarouselContext);
   const viewportRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+  const interpretersRef = useRef(interpreters);
 
-  // Mount interpreters for this item.
   useEffect(() => {
     if (!ctx) return;
     const { store } = ctx;
     const viewport = viewportRef.current;
     if (!viewport) return;
 
-    const interpreters: MountedInterpreter[] = [
-      withItemId(touchInterpreter()(viewport), id),
-      withItemId(mouseDragInterpreter()(viewport), id),
-      withItemId(mouseWheelInterpreter()(viewport), id),
-      withItemId(doubleTapInterpreter()(viewport), id),
-    ];
-
-    const unmounts = interpreters.map((interp) =>
-      interp.subscribe((e) => store.dispatch(e)),
+    const mounted: MountedInterpreter[] = interpretersRef.current.map(
+      (interp) => withItemId(interp(viewport), id),
     );
+    const stops = mounted.map((m) => m.subscribe((e) => store.dispatch(e)));
+
     return () => {
-      for (const unmount of unmounts) unmount();
-      for (const interp of interpreters) interp.unmount();
+      for (const stop of stops) stop();
+      for (const m of mounted) m.unmount();
     };
   }, [ctx, id]);
 
-  // Subscribe to store and apply this item's transform.
   useEffect(() => {
     if (!ctx) return;
     return ctx.store.subscribe((state) => {
@@ -154,17 +148,12 @@ export function ScalableCarouselContainer({
     CarouselAction
   > | null>(null);
 
-  // Keep a ref to the latest itemIds so effects can read the current value
-  // without needing it in their dependency arrays (the array is a new reference
-  // every render even when content is unchanged).
   const itemIds = deriveItemIds(children);
   const itemIdsRef = useRef<readonly string[]>(itemIds);
   itemIdsRef.current = itemIds;
 
-  // Stable string key used as a dep to detect actual content changes.
   const itemIdsKey = itemIds.join(",");
 
-  // Create the store once per itemWidth/itemHeight.
   useEffect(() => {
     const s = createStore(
       createCarouselModel({
@@ -189,9 +178,6 @@ export function ScalableCarouselContainer({
     };
   }, [itemWidth, itemHeight]);
 
-  // Dispatch set-config whenever the item list changes after the store is ready.
-  // itemIdsKey is included as a trigger dep even though itemIdsRef.current is
-  // what's read inside — the ref is always current, the key signals the change.
   // biome-ignore lint/correctness/useExhaustiveDependencies: itemIdsKey is an intentional trigger dep for itemIdsRef.current
   useEffect(() => {
     if (!store) return;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,0 +1,6 @@
+export { PinchPanContainer } from "./PinchPanContainer.js";
+export { CarouselContainer } from "./CarouselContainer.js";
+export {
+  ScalableCarouselContainer,
+  ScalableCarouselItem,
+} from "./ScalableCarouselContainer.js";

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "lib": ["ES2020", "DOM"],
+    "jsx": "react-jsx",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Closes #19.

## Summary

- Creates `packages/react` (`@mimosa/react`) with `PinchPanContainer`, `CarouselContainer`, `ScalableCarouselContainer`, and `ScalableCarouselItem` extracted from `@mimosa/demo`.
- `interpreters` prop is **required** on all gesture-accepting components — callers instantiate interpreters directly from `@mimosa/core`, enabling tree-shaking.
- `modelOptions?: TransformConfig` prop is added to `PinchPanContainer` and `CarouselContainer` for passthrough to `createModel`. On `CarouselContainer`, a caller-supplied `snapTarget` overrides the default page-snap behaviour.
- `react` is a peer dependency of `@mimosa/react`.
- Exports `TransformConfig` from `@mimosa/core` (was previously unexported).
- `@mimosa/demo` updated to import from `@mimosa/react`; the three component source files are deleted from the demo.

CLAUDE: This PR was generated with Claude Code.