### PR TITLE
Add Store.flush(), navigate-to action, and grid+modal demo

### DIFF
--- a/design/00_architecture.md
+++ b/design/00_architecture.md
@@ -188,10 +188,15 @@ type CarouselConfig = {
   itemIds: readonly string[];   // ordered list of item identifiers
 };
 
-type CarouselAction = TransformAction | { type: "set-config"; config: CarouselConfig };
+type CarouselAction =
+  | TransformAction
+  | { type: "set-config"; config: CarouselConfig }
+  | { type: "navigate-to"; index: number };
 ```
 
 Dispatching `set-config` updates the item list while preserving carousel animation state. The carousel strip stays anchored to the item the gesture was heading toward; deleted items lose their transform state; new items start at the neutral transform. If the active item (currently being panned/zoomed) is deleted, the model transitions immediately to the `free` state.
+
+Dispatching `navigate-to` immediately moves the carousel strip to the given item index (clamped to the valid range), cancelling any in-progress gesture or animation. The model transitions to the `free` state.
 
 The private state is a tagged union that tracks whether a gesture is targeting the carousel strip or an individual item:
 
@@ -228,10 +233,14 @@ The Store has a continuous update loop driven by `requestAnimationFrame()`. The 
 
 The Store's update loop emits state to subscribers on every frame where the state changes. The loop pauses automatically when the reducer returns the same object reference as the previous state (indicating the state has settled), and resumes when `dispatch` is called. This pause/resume behavior is an implementation detail of the Store — other modules must not depend on it. The reference equality contract described in [State Machine Design](#state-machine-design) is what enables this optimization.
 
+`flush()` synchronously publishes the current state to all subscribers without waiting for the next animation frame. Use it when you need subscribers to reflect a `dispatch` call immediately — for example, to update the DOM before the browser paints.
+
 ```typescript
 type Store<TState, TAction = StoreAction> = {
   subscribe: (cb: Callback<TState>) => UnsubscribeFn;
   dispatch: (action: TAction) => void;
+  /** Synchronously fires all subscribers with the current public state. */
+  flush: () => void;
   unmount: UnmountFn;
 };
 

--- a/packages/core/src/model/carousel.ts
+++ b/packages/core/src/model/carousel.ts
@@ -31,7 +31,8 @@ export type CarouselPublicState = {
 
 export type CarouselAction =
   | TransformAction
-  | { type: "set-config"; config: CarouselConfig };
+  | { type: "set-config"; config: CarouselConfig }
+  | { type: "navigate-to"; index: number };
 
 // ---------------------------------------------------------------------------
 // Internal types
@@ -330,6 +331,20 @@ function createCarouselReduce(config: CarouselConfig) {
   ): CarouselPrivateState {
     if (action.type === "set-config") {
       return applySetConfig(state, action.config);
+    }
+
+    if (action.type === "navigate-to") {
+      const clampedIndex = Math.max(0, Math.min(itemCount - 1, action.index));
+      return {
+        type: "free",
+        itemIds: state.itemIds,
+        carousel: {
+          type: "settled",
+          transform: { x: -clampedIndex * itemWidth, y: 0, scale: 1 },
+          lastUpdatedAt: Number.NaN,
+        },
+        items: state.items,
+      };
     }
 
     switch (state.type) {

--- a/packages/core/src/renderer/__tests__/renderer.test.ts
+++ b/packages/core/src/renderer/__tests__/renderer.test.ts
@@ -13,6 +13,7 @@ function makeMockStore(): Store<State> & { emit: (s: State) => void } {
       return () => callbacks.delete(cb);
     },
     dispatch: vi.fn(),
+    flush: vi.fn(),
     unmount: vi.fn(),
   };
 }

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -47,6 +47,11 @@ export function createStore<TPrivateState, TState, TExtraAction = never>(
       state = model.reduce(state, action);
       resumeLoop();
     },
+    flush() {
+      lastEmittedState = state;
+      const publicState = model.publish(state);
+      for (const cb of callbacks) cb(publicState);
+    },
     unmount() {
       mounted = false;
       if (rafId !== null) cancelAnimationFrame(rafId);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -46,6 +46,7 @@ export type Interpreter = (element: HTMLElement) => MountedInterpreter;
 export type Store<TState, TAction = StoreAction> = {
   subscribe: (cb: Callback<TState>) => UnsubscribeFn;
   dispatch: (action: TAction) => void;
+  flush: () => void;
   unmount: UnmountFn;
 };
 

--- a/packages/demo/src/ScalableCarouselDemo.tsx
+++ b/packages/demo/src/ScalableCarouselDemo.tsx
@@ -29,6 +29,20 @@ export function ScalableCarouselDemo() {
   const [items, setItems] = useState(INITIAL_ITEMS);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const nextItemIdRef = useRef(INITIAL_ITEMS.length);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  function openModal(index: number) {
+    setSelectedIndex(index);
+    dialogRef.current?.showModal();
+  }
+
+  function closeModal() {
+    dialogRef.current?.close();
+  }
+
+  function handleBackdropClick(e: React.MouseEvent<HTMLDialogElement>) {
+    if (e.target === e.currentTarget) closeModal();
+  }
 
   function addItemAt(index: number) {
     const n = nextItemIdRef.current++;
@@ -50,84 +64,129 @@ export function ScalableCarouselDemo() {
   }
 
   return (
-    <div className="flex-1 flex flex-col justify-center bg-gray-900">
-      <ScalableCarouselContainer
-        itemWidth={ITEM_WIDTH}
-        itemHeight={ITEM_HEIGHT}
-      >
-        {items.map(({ id, photoId }) => (
-          <ScalableCarouselItem key={id} id={id} interpreters={interpreters}>
+    <div className="flex-1 overflow-auto bg-gray-900 p-4">
+      <div className="grid grid-cols-3 gap-2">
+        {items.map(({ id, photoId }, index) => (
+          <button
+            key={id}
+            type="button"
+            className="aspect-square overflow-hidden rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+            onClick={() => openModal(index)}
+          >
             <img
-              src={`https://picsum.photos/id/${photoId}/${ITEM_WIDTH}/${ITEM_HEIGHT}`}
+              src={`https://picsum.photos/id/${photoId}/300/300`}
               alt={id}
               draggable={false}
-              style={{
-                display: "block",
-                width: "100%",
-                height: "100%",
-                objectFit: "cover",
-                userSelect: "none",
-              }}
+              className="w-full h-full object-cover"
             />
-          </ScalableCarouselItem>
-        ))}
-      </ScalableCarouselContainer>
-      <div className="flex items-center justify-center gap-4 text-sm py-2">
-        {items.length === 0 ? (
-          <button
-            type="button"
-            className="px-3 py-1 rounded bg-indigo-600 text-white hover:bg-indigo-500"
-            onClick={() => addItemAt(0)}
-          >
-            Add Item
           </button>
-        ) : (
-          <>
-            <div className="flex items-center gap-2 text-gray-400">
-              <button
-                type="button"
-                className="px-2 py-1 rounded hover:text-white disabled:opacity-30"
-                disabled={selectedIndex === 0}
-                onClick={() => setSelectedIndex((i) => i - 1)}
-              >
-                ←
-              </button>
-              <span>
-                Item {selectedIndex + 1} of {items.length}
-              </span>
-              <button
-                type="button"
-                className="px-2 py-1 rounded hover:text-white disabled:opacity-30"
-                disabled={selectedIndex === items.length - 1}
-                onClick={() => setSelectedIndex((i) => i + 1)}
-              >
-                →
-              </button>
-            </div>
-            <button
-              type="button"
-              className="px-3 py-1 rounded bg-indigo-600 text-white hover:bg-indigo-500"
-              onClick={() => addItemAt(selectedIndex)}
-            >
-              Add Before
-            </button>
-            <button
-              type="button"
-              className="px-3 py-1 rounded bg-indigo-600 text-white hover:bg-indigo-500"
-              onClick={() => addItemAt(selectedIndex + 1)}
-            >
-              Add After
-            </button>
-            <button
-              type="button"
-              className="px-3 py-1 rounded bg-rose-700 text-white hover:bg-rose-600"
-              onClick={() => removeItemAt(selectedIndex)}
-            >
-              Remove
-            </button>
-          </>
-        )}
+        ))}
       </div>
+
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: <dialog> natively closes on Escape */}
+      <dialog
+        ref={dialogRef}
+        className="bg-gray-900 p-0 max-w-none max-h-none w-screen h-screen backdrop:bg-black/60"
+        onClick={handleBackdropClick}
+      >
+        <div className="flex flex-col h-full">
+          <div className="flex justify-end px-4 py-2 shrink-0">
+            <button
+              type="button"
+              className="text-gray-400 hover:text-white text-2xl leading-none"
+              onClick={closeModal}
+            >
+              ✕
+            </button>
+          </div>
+
+          <div className="flex-1 flex flex-col justify-center overflow-hidden">
+            <ScalableCarouselContainer
+              itemWidth={ITEM_WIDTH}
+              itemHeight={ITEM_HEIGHT}
+              selectedIndex={selectedIndex}
+            >
+              {items.map(({ id, photoId }) => (
+                <ScalableCarouselItem
+                  key={id}
+                  id={id}
+                  interpreters={interpreters}
+                >
+                  <img
+                    src={`https://picsum.photos/id/${photoId}/${ITEM_WIDTH}/${ITEM_HEIGHT}`}
+                    alt={id}
+                    draggable={false}
+                    style={{
+                      display: "block",
+                      width: "100%",
+                      height: "100%",
+                      objectFit: "cover",
+                      userSelect: "none",
+                    }}
+                  />
+                </ScalableCarouselItem>
+              ))}
+            </ScalableCarouselContainer>
+          </div>
+
+          <div className="flex items-center justify-center gap-4 text-sm py-2 shrink-0">
+            {items.length === 0 ? (
+              <button
+                type="button"
+                className="px-3 py-1 rounded bg-indigo-600 text-white hover:bg-indigo-500"
+                onClick={() => addItemAt(0)}
+              >
+                Add Item
+              </button>
+            ) : (
+              <>
+                <div className="flex items-center gap-2 text-gray-400">
+                  <button
+                    type="button"
+                    className="px-2 py-1 rounded hover:text-white disabled:opacity-30"
+                    disabled={selectedIndex === 0}
+                    onClick={() => setSelectedIndex((i) => i - 1)}
+                  >
+                    ←
+                  </button>
+                  <span>
+                    Item {selectedIndex + 1} of {items.length}
+                  </span>
+                  <button
+                    type="button"
+                    className="px-2 py-1 rounded hover:text-white disabled:opacity-30"
+                    disabled={selectedIndex === items.length - 1}
+                    onClick={() => setSelectedIndex((i) => i + 1)}
+                  >
+                    →
+                  </button>
+                </div>
+                <button
+                  type="button"
+                  className="px-3 py-1 rounded bg-indigo-600 text-white hover:bg-indigo-500"
+                  onClick={() => addItemAt(selectedIndex)}
+                >
+                  Add Before
+                </button>
+                <button
+                  type="button"
+                  className="px-3 py-1 rounded bg-indigo-600 text-white hover:bg-indigo-500"
+                  onClick={() => addItemAt(selectedIndex + 1)}
+                >
+                  Add After
+                </button>
+                <button
+                  type="button"
+                  className="px-3 py-1 rounded bg-rose-700 text-white hover:bg-rose-600"
+                  onClick={() => removeItemAt(selectedIndex)}
+                >
+                  Remove
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      </dialog>
     </div>
   );
 }

--- a/packages/react/src/ScalableCarouselContainer.tsx
+++ b/packages/react/src/ScalableCarouselContainer.tsx
@@ -4,6 +4,7 @@ import {
   isValidElement,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -123,6 +124,7 @@ type Props = {
   children?: ReactNode;
   itemWidth: number;
   itemHeight: number;
+  selectedIndex?: number;
   className?: string;
 };
 
@@ -140,6 +142,7 @@ export function ScalableCarouselContainer({
   children,
   itemWidth,
   itemHeight,
+  selectedIndex,
   className,
 }: Props) {
   const stripRef = useRef<HTMLDivElement>(null);
@@ -186,6 +189,12 @@ export function ScalableCarouselContainer({
       config: { itemWidth, itemHeight, itemIds: itemIdsRef.current },
     });
   }, [store, itemWidth, itemHeight, itemIdsKey]);
+
+  useLayoutEffect(() => {
+    if (selectedIndex === undefined || !store) return;
+    store.dispatch({ type: "navigate-to", index: selectedIndex });
+    store.flush();
+  }, [store, selectedIndex]);
 
   const contextValue = useMemo(
     () => (store ? { store, itemWidth, itemHeight } : null),


### PR DESCRIPTION
CLAUDE:

## Summary

- **`Store.flush()`**: new method that synchronously fires all subscribers with the current public state, without waiting for the next animation frame. Useful when a `dispatch` call must be reflected in the DOM before the browser paints.
- **`navigate-to` action** on `CarouselModel`: immediately moves the carousel strip to a given index (clamped), cancelling any in-progress gesture or animation. Works from any state at any time.
- **`selectedIndex` prop** on `ScalableCarouselContainer`: synced via `useLayoutEffect` — dispatches `navigate-to` then calls `flush()` so subscribers update before the first paint. Enables fully controlled index from outside the component.
- **`ScalableCarouselDemo` rewrite**: replaced the full-page carousel with a 3-column photo grid. Clicking a thumbnail opens a native `<dialog>` modal with the full scalable carousel, jumping to the clicked photo. Add/remove and prev/next controls live inside the modal. Closes via ✕ button, backdrop click, or Escape.

## Test plan

- [ ] Clicking a thumbnail opens the modal at the correct photo (no flash to photo 1)
- [ ] Prev/next arrow buttons navigate the carousel
- [ ] Add Before / Add After / Remove work as before
- [ ] Clicking the backdrop closes the modal
- [ ] Pressing Escape closes the modal
- [ ] ✕ button closes the modal
- [ ] `npm run tsc && npm run format && npm run lint && npm run test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)