### PR TITLE
Add touch slop: pending interpreter state and slop event

### DIFF
--- a/design/00_architecture.md
+++ b/design/00_architecture.md
@@ -30,7 +30,7 @@ interface Model<TPublicState, TPrivateState, TAction = StoreAction> {
 }
 ```
 
-**InterpreterEvent** is the output of an Interpreter. It is a tagged union that covers gesture movement, the moment the user releases the gesture, and discrete tap gestures. The motion fields (`dx`, `dy`, `dScale`, `originX`, `originY`) are inlined directly into the `motion` variant. For pan-only gestures, `dScale` is `1` and `originX/Y` are `0`.
+**InterpreterEvent** is the output of an Interpreter. It is a tagged union that covers gesture movement, the moment the user releases the gesture, and discrete tap gestures. The motion fields (`dx`, `dy`, `dScale`, `originX`, `originY`) are inlined directly into the `motion` and `slop` variants. For pan-only gestures, `dScale` is `1` and `originX/Y` are `0`.
 
 ```typescript
 type InterpreterEvent =
@@ -42,9 +42,15 @@ type InterpreterEvent =
       originX: number; // scale origin X, relative to the element's top-left corner (px)
       originY: number; // scale origin Y, relative to the element's top-left corner (px)
     }
+  | {
+      type: 'slop'; itemId?: string; timestamp: number;
+      dx: number; dy: number; dScale: number; originX: number; originY: number;
+    }
   | { type: 'release'; itemId?: string }
   | { type: 'toggle-zoom'; itemId?: string; originX: number; originY: number; timestamp: number };
 ```
+
+The `slop` variant carries the same fields as `motion` and represents the displacement between the initial `touchstart` position and the first `touchmove` position — the distance consumed by the browser's touch slop threshold. Models ignore `slop` (it does not move the element); it is available for gesture-direction detection.
 
 The optional `itemId` field identifies which item within a multi-item container (e.g. a carousel) the gesture targets. It is absent for container-level gestures such as swiping the carousel strip itself.
 
@@ -123,11 +129,11 @@ Implementation details:
 
 Each stateful interpreter models its internal state as a tagged union following the library-wide [State Machine Design](#state-machine-design) principles:
 
-- `touchInterpreter`: `no_touch | single_touch | multi_touch`
+- `touchInterpreter`: `no_touch | pending | single_touch | multi_touch`
 - `mouseDragInterpreter`: `idle | dragging`
 - `doubleTapInterpreter`: `idle | awaiting_second_tap`
 
-For example, a `single_touch` state necessarily carries exactly one touch point, and a `multi_touch` state necessarily carries exactly two. `touchInterpreter` can transition `no_touch → single_touch` and `single_touch → multi_touch`, but not `no_touch → multi_touch` directly.
+For example, a `single_touch` state necessarily carries exactly one touch point, and a `multi_touch` state necessarily carries exactly two. The `pending` state is entered when the first finger lands (`no_touch → pending`) and holds that initial touch point. The first `touchmove` from `pending` emits a `slop` event and transitions to `single_touch`; a second finger added during `pending` transitions directly to `multi_touch`. `touchInterpreter` can transition `no_touch → multi_touch` directly when the browser fires a `touchstart` with two simultaneous touches (e.g. mobile Safari).
 
 Each action corresponds to a DOM event. Side effects are confined to the thin `dispatch()` wrapper inside each interpreter factory, which calls `reduce`, updates the stored state, and emits the `InterpreterEvent` if one was returned.
 

--- a/packages/core/src/interpreter/__tests__/touch.test.ts
+++ b/packages/core/src/interpreter/__tests__/touch.test.ts
@@ -35,7 +35,6 @@ describe("touchInterpreter", () => {
 
   beforeEach(() => {
     element = document.createElement("div");
-    // Give element a bounding rect
     vi.spyOn(element, "getBoundingClientRect").mockReturnValue({
       left: 0,
       top: 0,
@@ -50,7 +49,7 @@ describe("touchInterpreter", () => {
     document.body.appendChild(element);
   });
 
-  it("emits pan motion on single-touch drag", () => {
+  it("emits slop on first single-touch move", () => {
     const interpreter = touchInterpreter()(element);
     const events: unknown[] = [];
     interpreter.subscribe((e) => events.push(e));
@@ -64,7 +63,7 @@ describe("touchInterpreter", () => {
 
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({
-      type: "motion",
+      type: "slop",
       dx: 10,
       dy: 20,
       dScale: 1,
@@ -76,12 +75,95 @@ describe("touchInterpreter", () => {
     interpreter.unmount();
   });
 
-  it("emits pinch motion on two-touch gesture", () => {
+  it("emits motion (not slop) on subsequent touchmoves", () => {
     const interpreter = touchInterpreter()(element);
     const events: unknown[] = [];
     interpreter.subscribe((e) => events.push(e));
 
-    // Start with two fingers 100px apart
+    element.dispatchEvent(
+      makeTouchEvent("touchstart", [makeTouch(0, 100, 100)]),
+    );
+    element.dispatchEvent(
+      makeTouchEvent("touchmove", [makeTouch(0, 110, 120)]),
+    );
+    element.dispatchEvent(
+      makeTouchEvent("touchmove", [makeTouch(0, 115, 125)]),
+    );
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({ type: "slop" });
+    expect(events[1]).toMatchObject({ type: "motion", dx: 5, dy: 5 });
+
+    interpreter.unmount();
+  });
+
+  it("emits release when touchend fires before any touchmove", () => {
+    const interpreter = touchInterpreter()(element);
+    const events: unknown[] = [];
+    interpreter.subscribe((e) => events.push(e));
+
+    element.dispatchEvent(
+      makeTouchEvent("touchstart", [makeTouch(0, 100, 100)]),
+    );
+    element.dispatchEvent(makeTouchEvent("touchend", []));
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: "release" });
+
+    interpreter.unmount();
+  });
+
+  it("emits release when touchcancel fires before any touchmove", () => {
+    const interpreter = touchInterpreter()(element);
+    const events: unknown[] = [];
+    interpreter.subscribe((e) => events.push(e));
+
+    element.dispatchEvent(
+      makeTouchEvent("touchstart", [makeTouch(0, 100, 100)]),
+    );
+    element.dispatchEvent(makeTouchEvent("touchcancel", []));
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: "release" });
+
+    interpreter.unmount();
+  });
+
+  it("second touchstart during pending transitions to multi_touch (next move emits motion)", () => {
+    const interpreter = touchInterpreter()(element);
+    const events: unknown[] = [];
+    interpreter.subscribe((e) => events.push(e));
+
+    element.dispatchEvent(
+      makeTouchEvent("touchstart", [makeTouch(0, 50, 100)]),
+    );
+    // Second finger added before any touchmove
+    element.dispatchEvent(
+      makeTouchEvent("touchstart", [
+        makeTouch(0, 50, 100),
+        makeTouch(1, 150, 100),
+      ]),
+    );
+    // First touchmove with 2 fingers — should emit motion, not slop
+    element.dispatchEvent(
+      makeTouchEvent("touchmove", [
+        makeTouch(0, 50, 100),
+        makeTouch(1, 200, 100),
+      ]),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: "motion" });
+
+    interpreter.unmount();
+  });
+
+  it("emits pinch motion on two-touch gesture (simultaneous touchstart)", () => {
+    const interpreter = touchInterpreter()(element);
+    const events: unknown[] = [];
+    interpreter.subscribe((e) => events.push(e));
+
+    // Two fingers placed simultaneously (e.g. mobile Safari)
     element.dispatchEvent(
       makeTouchEvent("touchstart", [
         makeTouch(0, 50, 100),
@@ -97,13 +179,14 @@ describe("touchInterpreter", () => {
     );
 
     expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: "motion" });
     const e = events[0] as { dScale: number };
     expect(e.dScale).toBeCloseTo(2, 5);
 
     interpreter.unmount();
   });
 
-  it("emits release event on touchend", () => {
+  it("emits release event on touchend after motion", () => {
     const interpreter = touchInterpreter()(element);
     const events: unknown[] = [];
     interpreter.subscribe((e) => events.push(e));
@@ -117,6 +200,7 @@ describe("touchInterpreter", () => {
     element.dispatchEvent(makeTouchEvent("touchend", []));
 
     expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({ type: "slop" });
     expect(events[1]).toMatchObject({ type: "release" });
 
     interpreter.unmount();

--- a/packages/core/src/interpreter/touch.ts
+++ b/packages/core/src/interpreter/touch.ts
@@ -10,6 +10,7 @@ type TouchPoint = { x: number; y: number };
 
 type TouchState =
   | { type: "no_touch" }
+  | { type: "pending"; point: TouchPoint }
   | { type: "single_touch"; point: TouchPoint }
   | { type: "multi_touch"; points: [TouchPoint, TouchPoint] };
 
@@ -51,10 +52,42 @@ function reduce(state: TouchState, action: TouchAction): ReducerResult {
     case "no_touch":
       switch (action.type) {
         case "touchstart":
+          if (action.points.length === 1) {
+            return { state: { type: "pending", point: action.points[0] } };
+          }
+          return { state: stateFromPoints(action.points) };
         case "touchend":
         case "touchcancel":
         case "touchmove":
           return { state: stateFromPoints(action.points) };
+      }
+      throw new Error("unreachable");
+
+    case "pending":
+      switch (action.type) {
+        case "touchstart":
+          return { state: stateFromPoints(action.points) };
+        case "touchend":
+        case "touchcancel":
+          return { state: { type: "no_touch" }, event: { type: "release" } };
+        case "touchmove": {
+          if (action.points.length === 0) {
+            return { state: { type: "no_touch" } };
+          }
+          const curr = action.points[0];
+          return {
+            state: stateFromPoints(action.points),
+            event: {
+              type: "slop",
+              timestamp: action.timestamp,
+              dx: curr.x - state.point.x,
+              dy: curr.y - state.point.y,
+              dScale: 1,
+              originX: 0,
+              originY: 0,
+            },
+          };
+        }
       }
       throw new Error("unreachable");
 

--- a/packages/core/src/model/carousel.ts
+++ b/packages/core/src/model/carousel.ts
@@ -396,6 +396,8 @@ function createCarouselReduce(config: CarouselConfig) {
           }
           case "release":
             return state;
+          case "slop":
+            return state;
           case "toggle-zoom": {
             if (action.itemId === undefined) return state;
             const item = state.items[action.itemId];
@@ -451,6 +453,8 @@ function createCarouselReduce(config: CarouselConfig) {
           }
           case "toggle-zoom":
             return state;
+          case "slop":
+            return state;
           case "tick": {
             const carousel = carouselReduce(state.carousel, action);
             const items = advanceAllItems(state.items, action.timestamp);
@@ -492,6 +496,8 @@ function createCarouselReduce(config: CarouselConfig) {
               items,
             };
           }
+          case "slop":
+            return state;
           case "toggle-zoom": {
             if (action.itemId !== state.activeItemId) return state;
             return {

--- a/packages/core/src/model/transform.ts
+++ b/packages/core/src/model/transform.ts
@@ -231,6 +231,8 @@ export function createTransformReduce(config?: TransformConfig) {
             return state;
           case "toggle-zoom":
             return state;
+          case "slop":
+            return state;
         }
         throw new Error("unreachable");
       }
@@ -245,6 +247,8 @@ export function createTransformReduce(config?: TransformConfig) {
               lastUpdatedAt: state.lastUpdatedAt,
             };
           case "release":
+            return state;
+          case "slop":
             return state;
           case "tick": {
             const timestamp = action.timestamp;
@@ -331,6 +335,8 @@ export function createTransformReduce(config?: TransformConfig) {
             return state;
           case "toggle-zoom":
             return state;
+          case "slop":
+            return state;
           case "tick": {
             if (
               Math.abs(state.transform.x - state.target.x) < SNAP_THRESHOLD &&
@@ -380,6 +386,8 @@ export function createTransformReduce(config?: TransformConfig) {
           case "release":
             return state;
           case "tick":
+            return state;
+          case "slop":
             return state;
           case "toggle-zoom": {
             const target = computeToggleZoomTarget(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -15,6 +15,17 @@ export type InterpreterEvent =
       timestamp: number;
     }
   | {
+      type: "slop";
+      /** Identifies the item being interacted with. Absent for container-level gestures. */
+      itemId?: string;
+      dx: number;
+      dy: number;
+      dScale: number;
+      originX: number;
+      originY: number;
+      timestamp: number;
+    }
+  | {
       type: "release";
       /** Identifies the item being released. Absent for container-level gestures. */
       itemId?: string;


### PR DESCRIPTION
## Summary

- Adds a `pending` state to `touchInterpreter` that records the initial touch position and absorbs the browser's built-in touch slop distance
- The first `touchmove` from `pending` emits a `slop` event (same shape as `motion`) instead of `motion`, so the transform model ignores it and the position jump on gesture start is eliminated
- Adds `slop` to `InterpreterEvent`; all model reducers treat it as a no-op (available for future gesture-direction detection)

**Mobile Safari note**: simultaneous two-finger `touchstart` (Safari fires one event for both fingers) skips `pending` and goes directly to `multi_touch`; the pinch slop limitation on that path is a known accepted tradeoff.

## State transitions

```
no_touch + touchstart(1 finger)  → pending
no_touch + touchstart(2 fingers) → multi_touch  (Safari simultaneous)
pending  + touchmove             → slop event + single_touch
pending  + touchstart            → multi_touch
pending  + touchend/touchcancel  → release event + no_touch
```

## Test plan

- [x] First single-touch move emits `slop` with correct `dx`/`dy`
- [x] Second move emits `motion`
- [x] `touchend` before any move emits `release`
- [x] `touchcancel` before any move emits `release`
- [x] Second finger during `pending` → `multi_touch`; next move emits `motion` (no slop)
- [x] Simultaneous two-finger `touchstart` → first move emits `motion` with correct `dScale`
- [x] `release` still emitted after touchend following motion
- [x] All 137 tests pass

CLAUDE: Generated with [Claude Code](https://claude.ai/claude-code)