### PR TITLE
Add view transition from grid thumbnail to carousel modal

### DIFF
--- a/design/00_architecture.md
+++ b/design/00_architecture.md
@@ -9,7 +9,8 @@ All transformations in this library are expressed as a combination of transformX
 ```typescript
 type UnsubscribeFn = () => void;
 type UnmountFn = () => void;
-type Callback<T> = (value: T) => void;
+type InterpreterCallback<T> = (value: T) => void;
+type StateCallback<T> = (state: T, prevState: T) => void;
 ```
 
 **Reducer** is the core abstraction for state machines in this library. A Reducer is a pure function that takes the current state and an action, and returns the next state. The first call passes `undefined` for state; the reducer must return an initial state in that case.
@@ -107,7 +108,7 @@ Key interfaces and functions:
 ```typescript
 type Interpreter = (element: Element) => MountedInterpreter;
 type MountedInterpreter = {
-  subscribe: (cb: Callback<InterpreterEvent>) => UnsubscribeFn;
+  subscribe: (cb: InterpreterCallback<InterpreterEvent>) => UnsubscribeFn;
   unmount: UnmountFn;
 };
 
@@ -243,7 +244,7 @@ The Store's update loop emits state to subscribers on every frame where the stat
 
 ```typescript
 type Store<TState, TAction = StoreAction> = {
-  subscribe: (cb: Callback<TState>) => UnsubscribeFn;
+  subscribe: (cb: StateCallback<TState>) => UnsubscribeFn;
   dispatch: (action: TAction) => void;
   /** Synchronously fires all subscribers with the current public state. */
   flush: () => void;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,15 +1,16 @@
 export type {
-  UnsubscribeFn,
-  UnmountFn,
-  Callback,
-  InterpreterEvent,
-  State,
-  MountedInterpreter,
   Interpreter,
-  Store,
+  InterpreterCallback,
+  InterpreterEvent,
+  Model,
+  MountedInterpreter,
   MountedRenderer,
   Renderer,
-  Model,
+  State,
+  StateCallback,
+  Store,
+  UnmountFn,
+  UnsubscribeFn,
 } from "./types.js";
 
 export {

--- a/packages/core/src/interpreter/double-tap.ts
+++ b/packages/core/src/interpreter/double-tap.ts
@@ -1,7 +1,7 @@
 import type {
   Interpreter,
   MountedInterpreter,
-  Callback,
+  InterpreterCallback,
   InterpreterEvent,
   UnsubscribeFn,
 } from "../types.js";
@@ -15,7 +15,7 @@ type DoubleTapState =
 
 export function doubleTapInterpreter(): Interpreter {
   return (element: Element): MountedInterpreter => {
-    const callbacks = new Set<Callback<InterpreterEvent>>();
+    const callbacks = new Set<InterpreterCallback<InterpreterEvent>>();
     let state: DoubleTapState = { type: "idle" };
 
     function emit(event: InterpreterEvent) {
@@ -86,7 +86,7 @@ export function doubleTapInterpreter(): Interpreter {
     });
 
     return {
-      subscribe(cb: Callback<InterpreterEvent>): UnsubscribeFn {
+      subscribe(cb: InterpreterCallback<InterpreterEvent>): UnsubscribeFn {
         callbacks.add(cb);
         return () => callbacks.delete(cb);
       },

--- a/packages/core/src/interpreter/mouse-drag.ts
+++ b/packages/core/src/interpreter/mouse-drag.ts
@@ -1,8 +1,8 @@
 import type {
   Interpreter,
-  MountedInterpreter,
-  Callback,
+  InterpreterCallback,
   InterpreterEvent,
+  MountedInterpreter,
   UnsubscribeFn,
 } from "../types.js";
 
@@ -58,7 +58,7 @@ function reduce(state: MouseDragState, action: MouseDragAction): ReducerResult {
 
 export function mouseDragInterpreter(): Interpreter {
   return (element: Element): MountedInterpreter => {
-    const callbacks = new Set<Callback<InterpreterEvent>>();
+    const callbacks = new Set<InterpreterCallback<InterpreterEvent>>();
     let state: MouseDragState = { type: "idle" };
 
     function dispatch(action: MouseDragAction) {
@@ -91,7 +91,7 @@ export function mouseDragInterpreter(): Interpreter {
     window.addEventListener("mouseup", onMouseUp);
 
     return {
-      subscribe(cb: Callback<InterpreterEvent>): UnsubscribeFn {
+      subscribe(cb: InterpreterCallback<InterpreterEvent>): UnsubscribeFn {
         callbacks.add(cb);
         return () => callbacks.delete(cb);
       },

--- a/packages/core/src/interpreter/mouse-wheel.ts
+++ b/packages/core/src/interpreter/mouse-wheel.ts
@@ -1,8 +1,8 @@
 import type {
   Interpreter,
-  MountedInterpreter,
-  Callback,
+  InterpreterCallback,
   InterpreterEvent,
+  MountedInterpreter,
   UnsubscribeFn,
 } from "../types.js";
 
@@ -16,7 +16,7 @@ const SCALE_PER_PIXEL = 0.002;
 
 export function mouseWheelInterpreter(): Interpreter {
   return (element: Element): MountedInterpreter => {
-    const callbacks = new Set<Callback<InterpreterEvent>>();
+    const callbacks = new Set<InterpreterCallback<InterpreterEvent>>();
 
     function emit(event: InterpreterEvent) {
       for (const cb of callbacks) cb(event);
@@ -65,7 +65,7 @@ export function mouseWheelInterpreter(): Interpreter {
     });
 
     return {
-      subscribe(cb: Callback<InterpreterEvent>): UnsubscribeFn {
+      subscribe(cb: InterpreterCallback<InterpreterEvent>): UnsubscribeFn {
         callbacks.add(cb);
         return () => callbacks.delete(cb);
       },

--- a/packages/core/src/interpreter/touch.ts
+++ b/packages/core/src/interpreter/touch.ts
@@ -1,7 +1,7 @@
 import type {
   Interpreter,
   MountedInterpreter,
-  Callback,
+  InterpreterCallback,
   InterpreterEvent,
   UnsubscribeFn,
 } from "../types.js";
@@ -169,7 +169,7 @@ function reduce(state: TouchState, action: TouchAction): ReducerResult {
 
 export function touchInterpreter(): Interpreter {
   return (element: HTMLElement): MountedInterpreter => {
-    const callbacks = new Set<Callback<InterpreterEvent>>();
+    const callbacks = new Set<InterpreterCallback<InterpreterEvent>>();
     let state: TouchState = { type: "no_touch" };
 
     function dispatch(action: TouchAction) {
@@ -225,7 +225,7 @@ export function touchInterpreter(): Interpreter {
     });
 
     return {
-      subscribe(cb: Callback<InterpreterEvent>): UnsubscribeFn {
+      subscribe(cb: InterpreterCallback<InterpreterEvent>): UnsubscribeFn {
         callbacks.add(cb);
         return () => callbacks.delete(cb);
       },

--- a/packages/core/src/model/carousel.ts
+++ b/packages/core/src/model/carousel.ts
@@ -20,6 +20,8 @@ export type CarouselConfig = {
 };
 
 export type CarouselPublicState = {
+  /** True when the carousel strip has come to rest at a snap point. */
+  isCarouselSettled: boolean;
   /** Horizontal translation of the carousel strip (px). Negative = scrolled right. */
   carouselTranslateX: number;
   /** Per-item transform state keyed by item ID. */
@@ -124,7 +126,11 @@ function toCarouselPublicState(
       scale: item.transform.scale,
     };
   }
-  return { carouselTranslateX: state.carousel.transform.x, items };
+  return {
+    isCarouselSettled: state.carousel.type === "settled",
+    carouselTranslateX: state.carousel.transform.x,
+    items,
+  };
 }
 
 export function createCarouselModel(

--- a/packages/core/src/model/transform.ts
+++ b/packages/core/src/model/transform.ts
@@ -75,7 +75,7 @@ function computeMinScale(
   return minScale;
 }
 
-const SNAP_DECAY = 0.95; // per-frame interpolation factor toward snap target
+const SNAP_DECAY = 0.85; // per-frame interpolation factor toward snap target
 const SNAP_THRESHOLD = 0.5; // px
 const SCALE_SNAP_THRESHOLD = 0.001;
 const VELOCITY_THRESHOLD = 0.01; // px/ms

--- a/packages/core/src/renderer/__tests__/renderer.test.ts
+++ b/packages/core/src/renderer/__tests__/renderer.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, vi } from "vitest";
 import { createRenderer } from "../index.js";
-import type { Store, Callback, State } from "../../types.js";
+import type { Store, StateCallback, State } from "../../types.js";
 
 function makeMockStore(): Store<State> & { emit: (s: State) => void } {
-  const callbacks = new Set<Callback<State>>();
+  const callbacks = new Set<StateCallback<State>>();
   return {
     emit(s: State) {
-      for (const cb of callbacks) cb(s);
+      for (const cb of callbacks) cb(s, s);
     },
-    subscribe(cb: Callback<State>) {
+    subscribe(cb: StateCallback<State>) {
       callbacks.add(cb);
       return () => callbacks.delete(cb);
     },

--- a/packages/core/src/store/__tests__/store.test.ts
+++ b/packages/core/src/store/__tests__/store.test.ts
@@ -142,6 +142,22 @@ describe("createStore", () => {
     store.unmount();
   });
 
+  it("passes prevState on first emission equal to state, then the prior state on subsequent emissions", () => {
+    const store = createStore(counterModel((s) => s));
+    const pairs: Array<[CounterState, CounterState]> = [];
+    store.subscribe((s, prev) => pairs.push([s, prev]));
+
+    flushRaf();
+    expect(pairs[0][0]).toBe(pairs[0][1]); // first emission: state === prevState
+
+    store.dispatch(motionEvent);
+    flushRaf();
+    expect(pairs[1][0].motionCount).toBe(1);
+    expect(pairs[1][1].motionCount).toBe(0); // prevState is the prior emission
+
+    store.unmount();
+  });
+
   it("stops notifying after unmount", () => {
     const store = createStore(counterModel((s) => s));
     const snapshots: CounterState[] = [];

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -1,6 +1,6 @@
 import type {
   Store,
-  Callback,
+  StateCallback,
   UnsubscribeFn,
   Model,
   StoreAction,
@@ -9,9 +9,10 @@ import type {
 export function createStore<TPrivateState, TState, TExtraAction = never>(
   model: Model<TState, TPrivateState, StoreAction | TExtraAction>,
 ): Store<TState, StoreAction | TExtraAction> {
-  const callbacks = new Set<Callback<TState>>();
+  const callbacks = new Set<StateCallback<TState>>();
 
   let state = model.reduce(undefined, { type: "tick", timestamp: 0 });
+  let lastEmittedPublicState: TState = model.publish(state);
   let lastEmittedState: TPrivateState | undefined;
 
   let rafId: number | null = null;
@@ -26,7 +27,9 @@ export function createStore<TPrivateState, TState, TExtraAction = never>(
     }
     lastEmittedState = state;
     const publicState = model.publish(state);
-    for (const cb of callbacks) cb(publicState);
+    const prevPublicState = lastEmittedPublicState;
+    lastEmittedPublicState = publicState;
+    for (const cb of callbacks) cb(publicState, prevPublicState);
     rafId = requestAnimationFrame(loop);
   }
 
@@ -39,7 +42,7 @@ export function createStore<TPrivateState, TState, TExtraAction = never>(
   rafId = requestAnimationFrame(loop);
 
   return {
-    subscribe(cb: Callback<TState>): UnsubscribeFn {
+    subscribe(cb: StateCallback<TState>): UnsubscribeFn {
       callbacks.add(cb);
       return () => callbacks.delete(cb);
     },
@@ -48,9 +51,11 @@ export function createStore<TPrivateState, TState, TExtraAction = never>(
       resumeLoop();
     },
     flush() {
-      lastEmittedState = state;
       const publicState = model.publish(state);
-      for (const cb of callbacks) cb(publicState);
+      const prevPublicState = lastEmittedPublicState;
+      lastEmittedPublicState = publicState;
+      lastEmittedState = state;
+      for (const cb of callbacks) cb(publicState, prevPublicState);
     },
     unmount() {
       mounted = false;

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -12,7 +12,7 @@ export function createStore<TPrivateState, TState, TExtraAction = never>(
   const callbacks = new Set<StateCallback<TState>>();
 
   let state = model.reduce(undefined, { type: "tick", timestamp: 0 });
-  let lastEmittedPublicState: TState = model.publish(state);
+  let lastEmittedPublicState: TState | undefined;
   let lastEmittedState: TPrivateState | undefined;
 
   let rafId: number | null = null;
@@ -27,7 +27,7 @@ export function createStore<TPrivateState, TState, TExtraAction = never>(
     }
     lastEmittedState = state;
     const publicState = model.publish(state);
-    const prevPublicState = lastEmittedPublicState;
+    const prevPublicState = lastEmittedPublicState ?? publicState;
     lastEmittedPublicState = publicState;
     for (const cb of callbacks) cb(publicState, prevPublicState);
     rafId = requestAnimationFrame(loop);
@@ -52,7 +52,7 @@ export function createStore<TPrivateState, TState, TExtraAction = never>(
     },
     flush() {
       const publicState = model.publish(state);
-      const prevPublicState = lastEmittedPublicState;
+      const prevPublicState = lastEmittedPublicState ?? publicState;
       lastEmittedPublicState = publicState;
       lastEmittedState = state;
       for (const cb of callbacks) cb(publicState, prevPublicState);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,7 @@
 export type UnsubscribeFn = () => void;
 export type UnmountFn = () => void;
-export type Callback<T> = (value: T) => void;
+export type InterpreterCallback<T> = (value: T) => void;
+export type StateCallback<T> = (state: T, prevState: T) => void;
 
 export type InterpreterEvent =
   | {
@@ -48,14 +49,14 @@ export type State = {
 };
 
 export type MountedInterpreter = {
-  subscribe: (cb: Callback<InterpreterEvent>) => UnsubscribeFn;
+  subscribe: (cb: InterpreterCallback<InterpreterEvent>) => UnsubscribeFn;
   unmount: UnmountFn;
 };
 
 export type Interpreter = (element: HTMLElement) => MountedInterpreter;
 
 export type Store<TState, TAction = StoreAction> = {
-  subscribe: (cb: Callback<TState>) => UnsubscribeFn;
+  subscribe: (cb: StateCallback<TState>) => UnsubscribeFn;
   dispatch: (action: TAction) => void;
   flush: () => void;
   unmount: UnmountFn;

--- a/packages/demo/src/ScalableCarouselDemo.tsx
+++ b/packages/demo/src/ScalableCarouselDemo.tsx
@@ -54,7 +54,7 @@ export function ScalableCarouselDemo() {
       dialogRef.current?.showModal();
       carouselImg?.style.setProperty("view-transition-name", "selected-photo");
     });
-    transition.finished.then(() => {
+    transition.finished.finally(() => {
       carouselImg?.style.removeProperty("view-transition-name");
     });
   }
@@ -73,7 +73,7 @@ export function ScalableCarouselDemo() {
       carouselImg?.style.removeProperty("view-transition-name");
       gridImg?.style.setProperty("view-transition-name", "selected-photo");
     });
-    transition.finished.then(() => {
+    transition.finished.finally(() => {
       gridImg?.style.removeProperty("view-transition-name");
     });
   }
@@ -123,7 +123,7 @@ export function ScalableCarouselDemo() {
             opacity: 1 !important;
             mix-blend-mode: normal !important;
 
-            // Place the image in the center of the container and make it cover the area, similar to object-fit: cover
+            /* Place the image in the center of the container and make it cover the area, similar to object-fit: cover */
             position: absolute;
             top: 50%;
             left: 50%;

--- a/packages/demo/src/ScalableCarouselDemo.tsx
+++ b/packages/demo/src/ScalableCarouselDemo.tsx
@@ -28,11 +28,13 @@ const interpreters = [
 
 export function ScalableCarouselDemo() {
   const [items, setItems] = useState(INITIAL_ITEMS);
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [selectedItemId, setSelectedItemId] = useState(INITIAL_ITEMS[0].id);
   const nextItemIdRef = useRef(INITIAL_ITEMS.length);
   const dialogRef = useRef<HTMLDialogElement>(null);
   const gridImgRefs = useRef(new Map<string, HTMLImageElement>());
   const carouselImgRefs = useRef(new Map<string, HTMLImageElement>());
+
+  const selectedIndex = items.findIndex((i) => i.id === selectedItemId);
 
   function openModal(index: number) {
     const { id } = items[index];
@@ -40,14 +42,14 @@ export function ScalableCarouselDemo() {
     const carouselImg = carouselImgRefs.current.get(id);
 
     if (!document.startViewTransition) {
-      setSelectedIndex(index);
+      setSelectedItemId(id);
       dialogRef.current?.showModal();
       return;
     }
 
     gridImg?.style.setProperty("view-transition-name", "selected-photo");
     const transition = document.startViewTransition(() => {
-      flushSync(() => setSelectedIndex(index));
+      flushSync(() => setSelectedItemId(id));
       gridImg?.style.removeProperty("view-transition-name");
       dialogRef.current?.showModal();
       carouselImg?.style.setProperty("view-transition-name", "selected-photo");
@@ -58,9 +60,8 @@ export function ScalableCarouselDemo() {
   }
 
   function closeModal() {
-    const { id } = items[selectedIndex];
-    const gridImg = gridImgRefs.current.get(id);
-    const carouselImg = carouselImgRefs.current.get(id);
+    const gridImg = gridImgRefs.current.get(selectedItemId);
+    const carouselImg = carouselImgRefs.current.get(selectedItemId);
 
     if (!document.startViewTransition) {
       dialogRef.current?.close();
@@ -92,25 +93,25 @@ export function ScalableCarouselDemo() {
       newItem,
       ...prev.slice(index),
     ]);
-    setSelectedIndex(index);
+    setSelectedItemId(newItem.id);
   }
 
   function removeItemAt(index: number) {
-    setItems((prev) => prev.filter((_, i) => i !== index));
-    setSelectedIndex(Math.max(0, Math.min(index, items.length - 2)));
+    const newItems = items.filter((_, i) => i !== index);
+    const newIndex = Math.max(0, Math.min(index, newItems.length - 1));
+    setItems(newItems);
+    setSelectedItemId(newItems[newIndex]?.id ?? "");
   }
 
   return (
     <div className="flex-1 overflow-auto bg-gray-900 p-4">
       <style>
-        {
-          `
+        {`
           ::view-transition-group(selected-photo) {
             animation-duration: 5000ms;
             animation-timing-function: ease-out;
           }
-          `
-        }
+          `}
       </style>
       <div className="grid grid-cols-3 gap-2">
         {items.map(({ id, photoId }, index) => (
@@ -155,7 +156,8 @@ export function ScalableCarouselDemo() {
             <ScalableCarouselContainer
               itemWidth={ITEM_WIDTH}
               itemHeight={ITEM_HEIGHT}
-              selectedIndex={selectedIndex}
+              selectedItemId={selectedItemId}
+              onSelectedItemIdChange={setSelectedItemId}
             >
               {items.map(({ id, photoId }) => (
                 <ScalableCarouselItem
@@ -200,7 +202,9 @@ export function ScalableCarouselDemo() {
                     type="button"
                     className="px-2 py-1 rounded hover:text-white disabled:opacity-30"
                     disabled={selectedIndex === 0}
-                    onClick={() => setSelectedIndex((i) => i - 1)}
+                    onClick={() =>
+                      setSelectedItemId(items[selectedIndex - 1].id)
+                    }
                   >
                     ←
                   </button>
@@ -211,7 +215,9 @@ export function ScalableCarouselDemo() {
                     type="button"
                     className="px-2 py-1 rounded hover:text-white disabled:opacity-30"
                     disabled={selectedIndex === items.length - 1}
-                    onClick={() => setSelectedIndex((i) => i + 1)}
+                    onClick={() =>
+                      setSelectedItemId(items[selectedIndex + 1].id)
+                    }
                   >
                     →
                   </button>

--- a/packages/demo/src/ScalableCarouselDemo.tsx
+++ b/packages/demo/src/ScalableCarouselDemo.tsx
@@ -108,8 +108,30 @@ export function ScalableCarouselDemo() {
       <style>
         {`
           ::view-transition-group(selected-photo) {
-            animation-duration: 5000ms;
-            animation-timing-function: ease-out;
+            animation-duration: 400ms;
+            animation-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
+          }
+          ::view-transition-image-pair(selected-photo) {
+            overflow: hidden;
+            position: relative;
+            width: 100%;
+            height: 100%;
+            display: block;
+          }
+          ::view-transition-old(selected-photo),
+          ::view-transition-new(selected-photo) {
+            opacity: 1 !important;
+            mix-blend-mode: normal !important;
+
+            // Place the image in the center of the container and make it cover the area, similar to object-fit: cover
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            width: 100%;
+            height: 100%;
+
+            object-fit: cover;
           }
           `}
       </style>

--- a/packages/demo/src/ScalableCarouselDemo.tsx
+++ b/packages/demo/src/ScalableCarouselDemo.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from "react";
+import { flushSync } from "react-dom";
 import {
   touchInterpreter,
   mouseDragInterpreter,
@@ -30,14 +31,50 @@ export function ScalableCarouselDemo() {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const nextItemIdRef = useRef(INITIAL_ITEMS.length);
   const dialogRef = useRef<HTMLDialogElement>(null);
+  const gridImgRefs = useRef(new Map<string, HTMLImageElement>());
+  const carouselImgRefs = useRef(new Map<string, HTMLImageElement>());
 
   function openModal(index: number) {
-    setSelectedIndex(index);
-    dialogRef.current?.showModal();
+    const { id } = items[index];
+    const gridImg = gridImgRefs.current.get(id);
+    const carouselImg = carouselImgRefs.current.get(id);
+
+    if (!document.startViewTransition) {
+      setSelectedIndex(index);
+      dialogRef.current?.showModal();
+      return;
+    }
+
+    gridImg?.style.setProperty("view-transition-name", "selected-photo");
+    const transition = document.startViewTransition(() => {
+      flushSync(() => setSelectedIndex(index));
+      gridImg?.style.removeProperty("view-transition-name");
+      dialogRef.current?.showModal();
+      carouselImg?.style.setProperty("view-transition-name", "selected-photo");
+    });
+    transition.finished.then(() => {
+      carouselImg?.style.removeProperty("view-transition-name");
+    });
   }
 
   function closeModal() {
-    dialogRef.current?.close();
+    const { id } = items[selectedIndex];
+    const gridImg = gridImgRefs.current.get(id);
+    const carouselImg = carouselImgRefs.current.get(id);
+
+    if (!document.startViewTransition) {
+      dialogRef.current?.close();
+      return;
+    }
+    carouselImg?.style.setProperty("view-transition-name", "selected-photo");
+    const transition = document.startViewTransition(() => {
+      dialogRef.current?.close();
+      carouselImg?.style.removeProperty("view-transition-name");
+      gridImg?.style.setProperty("view-transition-name", "selected-photo");
+    });
+    transition.finished.then(() => {
+      gridImg?.style.removeProperty("view-transition-name");
+    });
   }
 
   function handleBackdropClick(e: React.MouseEvent<HTMLDialogElement>) {
@@ -65,6 +102,16 @@ export function ScalableCarouselDemo() {
 
   return (
     <div className="flex-1 overflow-auto bg-gray-900 p-4">
+      <style>
+        {
+          `
+          ::view-transition-group(selected-photo) {
+            animation-duration: 5000ms;
+            animation-timing-function: ease-out;
+          }
+          `
+        }
+      </style>
       <div className="grid grid-cols-3 gap-2">
         {items.map(({ id, photoId }, index) => (
           <button
@@ -74,6 +121,10 @@ export function ScalableCarouselDemo() {
             onClick={() => openModal(index)}
           >
             <img
+              ref={(el) => {
+                if (el) gridImgRefs.current.set(id, el);
+                else gridImgRefs.current.delete(id);
+              }}
               src={`https://picsum.photos/id/${photoId}/300/300`}
               alt={id}
               draggable={false}
@@ -113,6 +164,10 @@ export function ScalableCarouselDemo() {
                   interpreters={interpreters}
                 >
                   <img
+                    ref={(el) => {
+                      if (el) carouselImgRefs.current.set(id, el);
+                      else carouselImgRefs.current.delete(id);
+                    }}
                     src={`https://picsum.photos/id/${photoId}/${ITEM_WIDTH}/${ITEM_HEIGHT}`}
                     alt={id}
                     draggable={false}

--- a/packages/react/src/ScalableCarouselContainer.tsx
+++ b/packages/react/src/ScalableCarouselContainer.tsx
@@ -124,7 +124,8 @@ type Props = {
   children?: ReactNode;
   itemWidth: number;
   itemHeight: number;
-  selectedIndex?: number;
+  selectedItemId?: string;
+  onSelectedItemIdChange?: (itemId: string) => void;
   className?: string;
 };
 
@@ -142,7 +143,8 @@ export function ScalableCarouselContainer({
   children,
   itemWidth,
   itemHeight,
-  selectedIndex,
+  selectedItemId,
+  onSelectedItemIdChange,
   className,
 }: Props) {
   const stripRef = useRef<HTMLDivElement>(null);
@@ -154,6 +156,9 @@ export function ScalableCarouselContainer({
   const itemIds = deriveItemIds(children);
   const itemIdsRef = useRef<readonly string[]>(itemIds);
   itemIdsRef.current = itemIds;
+
+  const onSelectedItemIdChangeRef = useRef(onSelectedItemIdChange);
+  onSelectedItemIdChangeRef.current = onSelectedItemIdChange;
 
   const itemIdsKey = itemIds.join(",");
 
@@ -168,9 +173,18 @@ export function ScalableCarouselContainer({
 
     setStore(s);
 
-    const unsubscribe = s.subscribe((state) => {
+    const unsubscribe = s.subscribe((state, prevState) => {
       if (stripRef.current) {
         stripRef.current.style.transform = `translateX(${state.carouselTranslateX}px)`;
+      }
+      if (state.isCarouselSettled && !prevState.isCarouselSettled) {
+        const index = Math.round(-state.carouselTranslateX / itemWidth);
+        const clamped = Math.max(
+          0,
+          Math.min(itemIdsRef.current.length - 1, index),
+        );
+        const id = itemIdsRef.current[clamped];
+        if (id !== undefined) onSelectedItemIdChangeRef.current?.(id);
       }
     });
 
@@ -191,10 +205,12 @@ export function ScalableCarouselContainer({
   }, [store, itemWidth, itemHeight, itemIdsKey]);
 
   useLayoutEffect(() => {
-    if (selectedIndex === undefined || !store) return;
-    store.dispatch({ type: "navigate-to", index: selectedIndex });
+    if (selectedItemId === undefined || !store) return;
+    const index = itemIdsRef.current.indexOf(selectedItemId);
+    if (index === -1) return;
+    store.dispatch({ type: "navigate-to", index });
     store.flush();
-  }, [store, selectedIndex]);
+  }, [store, selectedItemId]);
 
   const contextValue = useMemo(
     () => (store ? { store, itemWidth, itemHeight } : null),


### PR DESCRIPTION
CLAUDE:

## Summary

- Animates the selected photo between the grid thumbnail and the carousel modal using the View Transition API, with a graceful fallback for browsers that don't support it.
- Tracks `selectedItemId` (string) instead of `selectedIndex` in the demo and `ScalableCarouselContainer`, and adds `onSelectedItemIdChange` callback so the parent is notified when the carousel settles at a new item after a swipe — fixing the close animation after swiping.
- Adds `StateCallback<T>` to the store subscriber API so callbacks receive `(state, prevState)`, enabling settle detection without per-subscriber prev-state refs.
- Refines the transition CSS so both screenshots are center-cropped during the aspect-ratio morph (square grid → portrait carousel), making the content stay aligned throughout.

## Test plan

- [ ] Open modal by clicking a grid thumbnail — photo should animate from thumbnail to carousel position.
- [ ] Close modal — photo should animate from carousel back to the correct thumbnail.
- [ ] Swipe carousel to a different item, then close — animation should land on the swiped-to thumbnail, not the originally opened one.
- [ ] Transition shape: the ghost should center-crop and expand from square to portrait on open, and contract on close, without content jumping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)