### PR TITLE
Add swipe-to-dismiss to carousel

### DIFF
--- a/design/00_architecture.md
+++ b/design/00_architecture.md
@@ -227,14 +227,14 @@ type CarouselPrivateState =
   | { type: "carousel";   itemIds: ...; carousel: TransformPrivateState; items: Record<string, TransformPrivateState> }
   | { type: "items";      itemIds: ...; carousel: TransformPrivateState; items: Record<string, TransformPrivateState>; activeItemId: string }
   | { type: "dismissing"; itemIds: ...; carousel: TransformPrivateState; items: Record<string, TransformPrivateState>; activeItemId: string; dismissX: number; dismissY: number; dismissVx: number; dismissVy: number; lastUpdatedAt: number }
-  | { type: "dismissed";  itemIds: ...; carousel: TransformPrivateState; items: Record<string, TransformPrivateState> };
+  | { type: "dismissed";  itemIds: ...; carousel: TransformPrivateState; items: Record<string, TransformPrivateState>; activeItemId: string; dismissX: number; dismissY: number };
 ```
 
 - **free** — no active gesture; animations may still be running on carousel or items.
 - **carousel** — gesture is scrolling the carousel strip.
 - **items** — gesture is targeting `activeItemId` for pan/zoom.
 - **dismissing** — user is actively swiping up/down to dismiss; position tracked in flat fields (not `TransformPrivateState`) because dismiss motion has no bounds and scale is derived from `y`.
-- **dismissed** — user released past the dismiss threshold; terminal state until the component unmounts.
+- **dismissed** — user released past the dismiss threshold; terminal state until the component unmounts. Retains `activeItemId`/`dismissX`/`dismissY` so the active item renders at the release position (needed for the view transition to start from the correct location).
 
 Tick advances both carousel and items animations in every phase.
 

--- a/design/00_architecture.md
+++ b/design/00_architecture.md
@@ -46,6 +46,7 @@ type InterpreterEvent =
   | {
       type: 'slop'; itemId?: string; timestamp: number;
       dx: number; dy: number; dScale: number; originX: number; originY: number;
+      pointerX: number; pointerY: number;  // initial touch position relative to element top-left (px)
     }
   | { type: 'release'; itemId?: string }
   | { type: 'toggle-zoom'; itemId?: string; originX: number; originY: number; timestamp: number };
@@ -226,15 +227,15 @@ type CarouselPrivateState =
   | { type: "free";       itemIds: ...; carousel: TransformPrivateState; items: Record<string, TransformPrivateState> }
   | { type: "carousel";   itemIds: ...; carousel: TransformPrivateState; items: Record<string, TransformPrivateState> }
   | { type: "items";      itemIds: ...; carousel: TransformPrivateState; items: Record<string, TransformPrivateState>; activeItemId: string }
-  | { type: "dismissing"; itemIds: ...; carousel: TransformPrivateState; items: Record<string, TransformPrivateState>; activeItemId: string; dismissX: number; dismissY: number; dismissVx: number; dismissVy: number; lastUpdatedAt: number }
-  | { type: "dismissed";  itemIds: ...; carousel: TransformPrivateState; items: Record<string, TransformPrivateState>; activeItemId: string; dismissX: number; dismissY: number };
+  | { type: "dismissing"; itemIds: ...; carousel: TransformPrivateState; items: Record<string, TransformPrivateState>; activeItemId: string; dismissX: number; dismissY: number; dismissVx: number; dismissVy: number; dismissPivotX: number; dismissPivotY: number; lastUpdatedAt: number }
+  | { type: "dismissed";  itemIds: ...; carousel: TransformPrivateState; items: Record<string, TransformPrivateState>; activeItemId: string; dismissX: number; dismissY: number; dismissPivotX: number; dismissPivotY: number };
 ```
 
 - **free** — no active gesture; animations may still be running on carousel or items.
 - **carousel** — gesture is scrolling the carousel strip.
 - **items** — gesture is targeting `activeItemId` for pan/zoom.
 - **dismissing** — user is actively swiping up/down to dismiss; position tracked in flat fields (not `TransformPrivateState`) because dismiss motion has no bounds and scale is derived from `y`.
-- **dismissed** — user released past the dismiss threshold; terminal state until the component unmounts. Retains `activeItemId`/`dismissX`/`dismissY` so the active item renders at the release position (needed for the view transition to start from the correct location).
+- **dismissed** — user released past the dismiss threshold; terminal state until the component unmounts. Retains `activeItemId`/`dismissX`/`dismissY`/`dismissPivotX`/`dismissPivotY` so the active item renders at the release position (needed for the view transition to start from the correct location).
 
 Tick advances both carousel and items animations in every phase.
 

--- a/design/00_architecture.md
+++ b/design/00_architecture.md
@@ -193,6 +193,7 @@ type CarouselConfig = {
   itemWidth: number;            // item container width (px)
   itemHeight: number;           // item container height (px)
   itemIds: readonly string[];   // ordered list of item identifiers
+  dismissible?: boolean;        // default false; gates slop → dismissing transition
 };
 
 type CarouselAction =
@@ -205,18 +206,35 @@ Dispatching `set-config` updates the item list while preserving carousel animati
 
 Dispatching `navigate-to` immediately moves the carousel strip to the given item index (clamped to the valid range), cancelling any in-progress gesture or animation. The model transitions to the `free` state.
 
+The public state includes a discriminated dismiss union:
+
+```typescript
+type CarouselPublicState = {
+  isCarouselSettled: boolean;
+  carouselTranslateX: number;
+  items: Record<string, { transformX: number; transformY: number; scale: number }>;
+} & (
+  | { isDismissed: false; dismissProgress: number }
+  | { isDismissed: true; dismissProgress: 1 }
+);
+```
+
 The private state is a tagged union that tracks whether a gesture is targeting the carousel strip or an individual item:
 
 ```typescript
 type CarouselPrivateState =
-  | { type: "free";     itemIds: ...; carousel: TransformPrivateState; items: Record<string, TransformPrivateState> }
-  | { type: "carousel"; itemIds: ...; carousel: TransformPrivateState; items: Record<string, TransformPrivateState> }
-  | { type: "items";    itemIds: ...; carousel: TransformPrivateState; items: Record<string, TransformPrivateState>; activeItemId: string };
+  | { type: "free";       itemIds: ...; carousel: TransformPrivateState; items: Record<string, TransformPrivateState> }
+  | { type: "carousel";   itemIds: ...; carousel: TransformPrivateState; items: Record<string, TransformPrivateState> }
+  | { type: "items";      itemIds: ...; carousel: TransformPrivateState; items: Record<string, TransformPrivateState>; activeItemId: string }
+  | { type: "dismissing"; itemIds: ...; carousel: TransformPrivateState; items: Record<string, TransformPrivateState>; activeItemId: string; dismissX: number; dismissY: number; dismissVx: number; dismissVy: number; lastUpdatedAt: number }
+  | { type: "dismissed";  itemIds: ...; carousel: TransformPrivateState; items: Record<string, TransformPrivateState> };
 ```
 
 - **free** — no active gesture; animations may still be running on carousel or items.
 - **carousel** — gesture is scrolling the carousel strip.
 - **items** — gesture is targeting `activeItemId` for pan/zoom.
+- **dismissing** — user is actively swiping up/down to dismiss; position tracked in flat fields (not `TransformPrivateState`) because dismiss motion has no bounds and scale is derived from `y`.
+- **dismissed** — user released past the dismiss threshold; terminal state until the component unmounts.
 
 Tick advances both carousel and items animations in every phase.
 

--- a/packages/core/src/interpreter/__tests__/touch.test.ts
+++ b/packages/core/src/interpreter/__tests__/touch.test.ts
@@ -67,6 +67,9 @@ describe("touchInterpreter", () => {
       dx: 10,
       dy: 20,
       dScale: 1,
+      // Initial touchstart position (100,100) relative to element rect (left:0, top:0)
+      pointerX: 100,
+      pointerY: 100,
     });
     expect(typeof (events[0] as { timestamp: unknown }).timestamp).toBe(
       "number",

--- a/packages/core/src/interpreter/touch.ts
+++ b/packages/core/src/interpreter/touch.ts
@@ -85,6 +85,8 @@ function reduce(state: TouchState, action: TouchAction): ReducerResult {
               dScale: 1,
               originX: 0,
               originY: 0,
+              pointerX: state.point.x - action.elementRect.left,
+              pointerY: state.point.y - action.elementRect.top,
             },
           };
         }

--- a/packages/core/src/model/__tests__/carousel.test.ts
+++ b/packages/core/src/model/__tests__/carousel.test.ts
@@ -1374,6 +1374,9 @@ describe("createCarouselModel", () => {
             b: makeSettledItem(),
             c: makeSettledItem(),
           },
+          activeItemId: "a",
+          dismissX: 0,
+          dismissY: -400,
         };
         expect(reduce(dismissed, { type: "tick", timestamp: 100 })).toBe(
           dismissed,
@@ -1393,7 +1396,7 @@ describe("createCarouselModel", () => {
         expect(pub.items.a.scale).toBeCloseTo(0.75);
       });
 
-      it("dismissed: isDismissed=true, dismissProgress=1", () => {
+      it("dismissed: isDismissed=true, dismissProgress=1, active item at dismiss position", () => {
         const { publish } = createCarouselModel(DISMISSIBLE_CONFIG);
         const dismissed: CarouselPrivateState = {
           type: "dismissed",
@@ -1406,10 +1409,22 @@ describe("createCarouselModel", () => {
             b: makeSettledItem(),
             c: makeSettledItem(),
           },
+          activeItemId: "a",
+          dismissX: 5,
+          dismissY: -400,
         };
         const pub = publish(dismissed);
         expect(pub.isDismissed).toBe(true);
         expect(pub.dismissProgress).toBe(1);
+        // Active item renders at the dismiss position, not the settled position,
+        // so the view transition captures the item where the user released it.
+        expect(pub.items.a.transformX).toBe(5);
+        expect(pub.items.a.transformY).toBe(-400);
+        expect(pub.items.a.scale).toBeCloseTo(
+          Math.max(0, 1 - 400 / (2 * ITEM_HEIGHT)),
+        );
+        // Non-active items use their settled positions.
+        expect(pub.items.b.transformY).toBe(0);
       });
     });
   });

--- a/packages/core/src/model/__tests__/carousel.test.ts
+++ b/packages/core/src/model/__tests__/carousel.test.ts
@@ -1189,6 +1189,8 @@ describe("createCarouselModel", () => {
   function makeDismissingState(
     dismissY = 0,
     dismissVy = 0,
+    dismissPivotX = 0,
+    dismissPivotY = 0,
   ): CarouselPrivateState {
     return {
       type: "dismissing",
@@ -1206,6 +1208,8 @@ describe("createCarouselModel", () => {
       dismissY,
       dismissVx: 0,
       dismissVy,
+      dismissPivotX,
+      dismissPivotY,
       lastUpdatedAt: 0,
     };
   }
@@ -1222,6 +1226,8 @@ describe("createCarouselModel", () => {
           dScale: 1,
           originX: 0,
           originY: 0,
+          pointerX: 200,
+          pointerY: 150,
           timestamp: 100,
         });
         expect(state.type).toBe("dismissing");
@@ -1229,6 +1235,8 @@ describe("createCarouselModel", () => {
           expect(state.activeItemId).toBe("a");
           expect(state.dismissX).toBe(0);
           expect(state.dismissY).toBe(0);
+          expect(state.dismissPivotX).toBe(200);
+          expect(state.dismissPivotY).toBe(150);
         }
       });
 
@@ -1243,6 +1251,8 @@ describe("createCarouselModel", () => {
           dScale: 1,
           originX: 0,
           originY: 0,
+          pointerX: 0,
+          pointerY: 0,
           timestamp: 100,
         });
         expect(after).toBe(before);
@@ -1259,6 +1269,8 @@ describe("createCarouselModel", () => {
           dScale: 1,
           originX: 0,
           originY: 0,
+          pointerX: 0,
+          pointerY: 0,
           timestamp: 100,
         });
         expect(after).toBe(before);
@@ -1291,6 +1303,8 @@ describe("createCarouselModel", () => {
           dScale: 1,
           originX: 0,
           originY: 0,
+          pointerX: 0,
+          pointerY: 0,
           timestamp: 100,
         });
         expect(after).toBe(snappingFree);
@@ -1307,6 +1321,8 @@ describe("createCarouselModel", () => {
           dScale: 1,
           originX: 0,
           originY: 0,
+          pointerX: 0,
+          pointerY: 0,
           timestamp: 100,
         });
         expect(after).toBe(before);
@@ -1377,6 +1393,8 @@ describe("createCarouselModel", () => {
           activeItemId: "a",
           dismissX: 0,
           dismissY: -400,
+          dismissPivotX: 0,
+          dismissPivotY: 0,
         };
         expect(reduce(dismissed, { type: "tick", timestamp: 100 })).toBe(
           dismissed,
@@ -1412,6 +1430,8 @@ describe("createCarouselModel", () => {
           activeItemId: "a",
           dismissX: 5,
           dismissY: -400,
+          dismissPivotX: 0,
+          dismissPivotY: 0,
         };
         const pub = publish(dismissed);
         expect(pub.isDismissed).toBe(true);

--- a/packages/core/src/model/__tests__/carousel.test.ts
+++ b/packages/core/src/model/__tests__/carousel.test.ts
@@ -25,8 +25,17 @@ const DEFAULT_CONFIG = {
   itemIds: ITEM_IDS,
 } as const;
 
+const DISMISSIBLE_CONFIG = {
+  ...DEFAULT_CONFIG,
+  dismissible: true,
+} as const;
+
 function makeReduce() {
   return createCarouselModel(DEFAULT_CONFIG).reduce;
+}
+
+function makeDismissibleReduce() {
+  return createCarouselModel(DISMISSIBLE_CONFIG).reduce;
 }
 
 /** Common transform/timestamp fields without velocity (settled/snapping). */
@@ -1158,6 +1167,8 @@ describe("createCarouselModel", () => {
       const state = free(-400, { a: { x: -10, y: 5, scale: 1.5 } });
       const pub = publish(state);
       expect(pub.carouselTranslateX).toBe(-400);
+      expect(pub.isDismissed).toBe(false);
+      expect(pub.dismissProgress).toBe(0);
       expect(pub.items.a).toEqual({
         transformX: -10,
         transformY: 5,
@@ -1167,6 +1178,238 @@ describe("createCarouselModel", () => {
         transformX: 0,
         transformY: 0,
         scale: 1,
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // dismiss gesture
+  // -------------------------------------------------------------------------
+
+  function makeDismissingState(
+    dismissY = 0,
+    dismissVy = 0,
+  ): CarouselPrivateState {
+    return {
+      type: "dismissing",
+      itemWidth: ITEM_WIDTH,
+      itemHeight: ITEM_HEIGHT,
+      itemIds: ITEM_IDS,
+      carousel: makeSettledCarousel(),
+      items: {
+        a: makeSettledItem(),
+        b: makeSettledItem(),
+        c: makeSettledItem(),
+      },
+      activeItemId: "a",
+      dismissX: 0,
+      dismissY,
+      dismissVx: 0,
+      dismissVy,
+      lastUpdatedAt: 0,
+    };
+  }
+
+  describe("dismiss gesture", () => {
+    describe("free + slop → dismissing", () => {
+      it("transitions when |dy|>|dx|, scale=1, carousel settled, dismissible=true", () => {
+        const reduce = makeDismissibleReduce();
+        const state = reduce(free(), {
+          type: "slop",
+          itemId: "a",
+          dx: 5,
+          dy: 20,
+          dScale: 1,
+          originX: 0,
+          originY: 0,
+          timestamp: 100,
+        });
+        expect(state.type).toBe("dismissing");
+        if (state.type === "dismissing") {
+          expect(state.activeItemId).toBe("a");
+          expect(state.dismissX).toBe(0);
+          expect(state.dismissY).toBe(0);
+        }
+      });
+
+      it("stays free when |dx|>=|dy| (horizontal swipe)", () => {
+        const reduce = makeDismissibleReduce();
+        const before = free();
+        const after = reduce(before, {
+          type: "slop",
+          itemId: "a",
+          dx: 20,
+          dy: 5,
+          dScale: 1,
+          originX: 0,
+          originY: 0,
+          timestamp: 100,
+        });
+        expect(after).toBe(before);
+      });
+
+      it("stays free when item scale != 1 (zoomed)", () => {
+        const reduce = makeDismissibleReduce();
+        const before = free(0, { a: { x: -50, y: -50, scale: 2 } });
+        const after = reduce(before, {
+          type: "slop",
+          itemId: "a",
+          dx: 5,
+          dy: 20,
+          dScale: 1,
+          originX: 0,
+          originY: 0,
+          timestamp: 100,
+        });
+        expect(after).toBe(before);
+      });
+
+      it("stays free when carousel is not settled", () => {
+        const reduce = makeDismissibleReduce();
+        const snappingFree: CarouselPrivateState = {
+          type: "free",
+          itemWidth: ITEM_WIDTH,
+          itemHeight: ITEM_HEIGHT,
+          itemIds: ITEM_IDS,
+          carousel: {
+            type: "snapping",
+            transform: { x: -200, y: 0, scale: 1 },
+            lastUpdatedAt: 0,
+            target: { x: -ITEM_WIDTH, y: 0, scale: 1 },
+          },
+          items: {
+            a: makeSettledItem(),
+            b: makeSettledItem(),
+            c: makeSettledItem(),
+          },
+        };
+        const after = reduce(snappingFree, {
+          type: "slop",
+          itemId: "a",
+          dx: 5,
+          dy: 20,
+          dScale: 1,
+          originX: 0,
+          originY: 0,
+          timestamp: 100,
+        });
+        expect(after).toBe(snappingFree);
+      });
+
+      it("stays free when dismissible=false", () => {
+        const reduce = makeReduce();
+        const before = free();
+        const after = reduce(before, {
+          type: "slop",
+          itemId: "a",
+          dx: 5,
+          dy: 20,
+          dScale: 1,
+          originX: 0,
+          originY: 0,
+          timestamp: 100,
+        });
+        expect(after).toBe(before);
+      });
+    });
+
+    describe("dismissing + motion", () => {
+      it("updates dismissX/Y and velocity", () => {
+        const reduce = makeDismissibleReduce();
+        const state = reduce(makeDismissingState(), {
+          type: "motion",
+          itemId: "a",
+          dx: 10,
+          dy: -50,
+          dScale: 1,
+          originX: 0,
+          originY: 0,
+          timestamp: 100,
+        });
+        expect(state.type).toBe("dismissing");
+        if (state.type === "dismissing") {
+          expect(state.dismissX).toBe(10);
+          expect(state.dismissY).toBe(-50);
+          expect(state.dismissVy).toBeCloseTo(-50 / 100);
+        }
+      });
+    });
+
+    describe("dismissing + release", () => {
+      it("transitions to dismissed when projected |y| > itemHeight * 0.5", () => {
+        // dismissY=-400, dismissVy=-5 → projected = -400 + (-5 / INERTIA_DECAY)
+        // INERTIA_DECAY ≈ 0.01005; projected ≈ -400 - 497 ≈ -897, well past threshold=300
+        const reduce = makeDismissibleReduce();
+        const state = reduce(makeDismissingState(-400, -5), {
+          type: "release",
+        });
+        expect(state.type).toBe("dismissed");
+      });
+
+      it("transitions to free with snapping item when projected |y| <= itemHeight * 0.5", () => {
+        // dismissY=-10, dismissVy=0 → projected = -10, threshold=300
+        const reduce = makeDismissibleReduce();
+        const state = reduce(makeDismissingState(-10, 0), { type: "release" });
+        expect(state.type).toBe("free");
+        if (state.type === "free") {
+          expect(state.items.a.type).toBe("snapping");
+          if (state.items.a.type === "snapping") {
+            expect(state.items.a.target).toEqual({ x: 0, y: 0, scale: 1 });
+          }
+        }
+      });
+    });
+
+    describe("dismissed + tick", () => {
+      it("returns same reference (animation loop stays paused)", () => {
+        const reduce = makeDismissibleReduce();
+        const dismissed: CarouselPrivateState = {
+          type: "dismissed",
+          itemWidth: ITEM_WIDTH,
+          itemHeight: ITEM_HEIGHT,
+          itemIds: ITEM_IDS,
+          carousel: makeSettledCarousel(),
+          items: {
+            a: makeSettledItem(),
+            b: makeSettledItem(),
+            c: makeSettledItem(),
+          },
+        };
+        expect(reduce(dismissed, { type: "tick", timestamp: 100 })).toBe(
+          dismissed,
+        );
+      });
+    });
+
+    describe("publish from dismissing/dismissed", () => {
+      it("dismissing: active item uses dismiss position/scale, dismissProgress computed from y", () => {
+        const { publish } = createCarouselModel(DISMISSIBLE_CONFIG);
+        // dismissY=-300 → progress = |−300| / (2*600) = 0.25; scale = 1 - 0.25 = 0.75
+        const state = makeDismissingState(-300, 0);
+        const pub = publish(state);
+        expect(pub.isDismissed).toBe(false);
+        expect(pub.dismissProgress).toBeCloseTo(0.25);
+        expect(pub.items.a.transformY).toBe(-300);
+        expect(pub.items.a.scale).toBeCloseTo(0.75);
+      });
+
+      it("dismissed: isDismissed=true, dismissProgress=1", () => {
+        const { publish } = createCarouselModel(DISMISSIBLE_CONFIG);
+        const dismissed: CarouselPrivateState = {
+          type: "dismissed",
+          itemWidth: ITEM_WIDTH,
+          itemHeight: ITEM_HEIGHT,
+          itemIds: ITEM_IDS,
+          carousel: makeSettledCarousel(),
+          items: {
+            a: makeSettledItem(),
+            b: makeSettledItem(),
+            c: makeSettledItem(),
+          },
+        };
+        const pub = publish(dismissed);
+        expect(pub.isDismissed).toBe(true);
+        expect(pub.dismissProgress).toBe(1);
       });
     });
   });

--- a/packages/core/src/model/carousel.ts
+++ b/packages/core/src/model/carousel.ts
@@ -98,6 +98,9 @@ export type CarouselPrivateState =
       itemIds: readonly string[];
       carousel: TransformPrivateState;
       items: Record<string, TransformPrivateState>;
+      activeItemId: string;
+      dismissX: number;
+      dismissY: number;
     };
 
 type MotionEvent = Extract<TransformAction, { type: "motion" }>;
@@ -150,16 +153,25 @@ function toCarouselPublicState(
   state: CarouselPrivateState,
 ): CarouselPublicState {
   if (state.type === "dismissed") {
+    const { activeItemId, dismissX, dismissY, itemHeight } = state;
     const items: Record<
       string,
       { transformX: number; transformY: number; scale: number }
     > = {};
     for (const [id, item] of Object.entries(state.items)) {
-      items[id] = {
-        transformX: item.transform.x,
-        transformY: item.transform.y,
-        scale: item.transform.scale,
-      };
+      if (id === activeItemId) {
+        items[id] = {
+          transformX: dismissX,
+          transformY: dismissY,
+          scale: deriveDismissScale(dismissY, itemHeight),
+        };
+      } else {
+        items[id] = {
+          transformX: item.transform.x,
+          transformY: item.transform.y,
+          scale: item.transform.scale,
+        };
+      }
     }
     return {
       isCarouselSettled: state.carousel.type === "settled",
@@ -717,6 +729,9 @@ function createCarouselReduce(config: CarouselConfig) {
                 itemIds: state.itemIds,
                 carousel: state.carousel,
                 items: state.items,
+                activeItemId: state.activeItemId,
+                dismissX: state.dismissX,
+                dismissY: state.dismissY,
               };
             }
             const activeItem = state.items[state.activeItemId];

--- a/packages/core/src/model/carousel.ts
+++ b/packages/core/src/model/carousel.ts
@@ -89,6 +89,8 @@ export type CarouselPrivateState =
       dismissY: number;
       dismissVx: number;
       dismissVy: number;
+      dismissPivotX: number;
+      dismissPivotY: number;
       lastUpdatedAt: number;
     }
   | {
@@ -101,6 +103,8 @@ export type CarouselPrivateState =
       activeItemId: string;
       dismissX: number;
       dismissY: number;
+      dismissPivotX: number;
+      dismissPivotY: number;
     };
 
 type MotionEvent = Extract<TransformAction, { type: "motion" }>;
@@ -153,17 +157,25 @@ function toCarouselPublicState(
   state: CarouselPrivateState,
 ): CarouselPublicState {
   if (state.type === "dismissed") {
-    const { activeItemId, dismissX, dismissY, itemHeight } = state;
+    const {
+      activeItemId,
+      dismissX,
+      dismissY,
+      dismissPivotX,
+      dismissPivotY,
+      itemHeight,
+    } = state;
     const items: Record<
       string,
       { transformX: number; transformY: number; scale: number }
     > = {};
     for (const [id, item] of Object.entries(state.items)) {
       if (id === activeItemId) {
+        const scale = deriveDismissScale(dismissY, itemHeight);
         items[id] = {
-          transformX: dismissX,
-          transformY: dismissY,
-          scale: deriveDismissScale(dismissY, itemHeight),
+          transformX: dismissX + dismissPivotX * (1 - scale),
+          transformY: dismissY + dismissPivotY * (1 - scale),
+          scale,
         };
       } else {
         items[id] = {
@@ -183,17 +195,25 @@ function toCarouselPublicState(
   }
 
   if (state.type === "dismissing") {
-    const { activeItemId, dismissX, dismissY, itemHeight } = state;
+    const {
+      activeItemId,
+      dismissX,
+      dismissY,
+      dismissPivotX,
+      dismissPivotY,
+      itemHeight,
+    } = state;
     const items: Record<
       string,
       { transformX: number; transformY: number; scale: number }
     > = {};
     for (const [id, item] of Object.entries(state.items)) {
       if (id === activeItemId) {
+        const scale = deriveDismissScale(dismissY, itemHeight);
         items[id] = {
-          transformX: dismissX,
-          transformY: dismissY,
-          scale: deriveDismissScale(dismissY, itemHeight),
+          transformX: dismissX + dismissPivotX * (1 - scale),
+          transformY: dismissY + dismissPivotY * (1 - scale),
+          scale,
         };
       } else {
         items[id] = {
@@ -553,6 +573,8 @@ function createCarouselReduce(config: CarouselConfig) {
                   dismissY: 0,
                   dismissVx: 0,
                   dismissVy: 0,
+                  dismissPivotX: action.pointerX,
+                  dismissPivotY: action.pointerY,
                   lastUpdatedAt: action.timestamp,
                 };
               }
@@ -732,9 +754,15 @@ function createCarouselReduce(config: CarouselConfig) {
                 activeItemId: state.activeItemId,
                 dismissX: state.dismissX,
                 dismissY: state.dismissY,
+                dismissPivotX: state.dismissPivotX,
+                dismissPivotY: state.dismissPivotY,
               };
             }
             const activeItem = state.items[state.activeItemId];
+            const snapScale = deriveDismissScale(
+              state.dismissY,
+              state.itemHeight,
+            );
             return {
               type: "free",
               itemWidth: state.itemWidth,
@@ -754,9 +782,9 @@ function createCarouselReduce(config: CarouselConfig) {
                     bottom: state.itemHeight,
                   },
                   transform: {
-                    x: state.dismissX,
-                    y: state.dismissY,
-                    scale: deriveDismissScale(state.dismissY, state.itemHeight),
+                    x: state.dismissX + state.dismissPivotX * (1 - snapScale),
+                    y: state.dismissY + state.dismissPivotY * (1 - snapScale),
+                    scale: snapScale,
                   },
                   lastUpdatedAt: state.lastUpdatedAt,
                   target: { x: 0, y: 0, scale: 1 },

--- a/packages/core/src/model/carousel.ts
+++ b/packages/core/src/model/carousel.ts
@@ -6,6 +6,7 @@ import {
   createTransformReduce,
   settleTransform,
 } from "./transform.js";
+import { computeDtMs } from "./primitives.js";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -18,6 +19,8 @@ export type CarouselConfig = {
   itemHeight: number;
   /** Ordered list of item identifiers. */
   itemIds: readonly string[];
+  /** When true, a vertical slop gesture on a scale=1 settled item enters dismissing state. */
+  dismissible?: boolean;
 };
 
 export type CarouselPublicState = {
@@ -30,7 +33,10 @@ export type CarouselPublicState = {
     string,
     { transformX: number; transformY: number; scale: number }
   >;
-};
+} & (
+  | { isDismissed: false; dismissProgress: number }
+  | { isDismissed: true; dismissProgress: 1 }
+);
 
 export type CarouselAction =
   | Exclude<TransformAction, { type: "set-bounds" }>
@@ -66,6 +72,32 @@ export type CarouselPrivateState =
       carousel: TransformPrivateState;
       items: Record<string, TransformPrivateState>;
       activeItemId: string;
+    }
+  | {
+      // Position tracked in flat fields rather than TransformPrivateState because
+      // dismiss motion has no bounds, no pinch scale, and scale is derived from y
+      // rather than tracked — reusing TransformPrivateState would conflict with its
+      // scale-tracking logic.
+      type: "dismissing";
+      itemWidth: number;
+      itemHeight: number;
+      itemIds: readonly string[];
+      carousel: TransformPrivateState;
+      items: Record<string, TransformPrivateState>;
+      activeItemId: string;
+      dismissX: number;
+      dismissY: number;
+      dismissVx: number;
+      dismissVy: number;
+      lastUpdatedAt: number;
+    }
+  | {
+      type: "dismissed";
+      itemWidth: number;
+      itemHeight: number;
+      itemIds: readonly string[];
+      carousel: TransformPrivateState;
+      items: Record<string, TransformPrivateState>;
     };
 
 type MotionEvent = Extract<TransformAction, { type: "motion" }>;
@@ -110,9 +142,64 @@ function computeCarouselSnapTarget(
 // Public API
 // ---------------------------------------------------------------------------
 
+function deriveDismissScale(y: number, itemHeight: number): number {
+  return Math.max(0, 1 - Math.abs(y) / (2 * itemHeight));
+}
+
 function toCarouselPublicState(
   state: CarouselPrivateState,
 ): CarouselPublicState {
+  if (state.type === "dismissed") {
+    const items: Record<
+      string,
+      { transformX: number; transformY: number; scale: number }
+    > = {};
+    for (const [id, item] of Object.entries(state.items)) {
+      items[id] = {
+        transformX: item.transform.x,
+        transformY: item.transform.y,
+        scale: item.transform.scale,
+      };
+    }
+    return {
+      isCarouselSettled: state.carousel.type === "settled",
+      carouselTranslateX: state.carousel.transform.x,
+      items,
+      isDismissed: true,
+      dismissProgress: 1,
+    };
+  }
+
+  if (state.type === "dismissing") {
+    const { activeItemId, dismissX, dismissY, itemHeight } = state;
+    const items: Record<
+      string,
+      { transformX: number; transformY: number; scale: number }
+    > = {};
+    for (const [id, item] of Object.entries(state.items)) {
+      if (id === activeItemId) {
+        items[id] = {
+          transformX: dismissX,
+          transformY: dismissY,
+          scale: deriveDismissScale(dismissY, itemHeight),
+        };
+      } else {
+        items[id] = {
+          transformX: item.transform.x,
+          transformY: item.transform.y,
+          scale: item.transform.scale,
+        };
+      }
+    }
+    return {
+      isCarouselSettled: state.carousel.type === "settled",
+      carouselTranslateX: state.carousel.transform.x,
+      items,
+      isDismissed: false,
+      dismissProgress: Math.min(1, Math.abs(dismissY) / (2 * itemHeight)),
+    };
+  }
+
   const items: Record<
     string,
     { transformX: number; transformY: number; scale: number }
@@ -128,6 +215,8 @@ function toCarouselPublicState(
     isCarouselSettled: state.carousel.type === "settled",
     carouselTranslateX: state.carousel.transform.x,
     items,
+    isDismissed: false,
+    dismissProgress: 0,
   };
 }
 
@@ -139,7 +228,7 @@ export function createCarouselModel(
 }
 
 function createCarouselReduce(config: CarouselConfig) {
-  const { itemWidth, itemHeight, itemIds } = config;
+  const { itemWidth, itemHeight, itemIds, dismissible = false } = config;
 
   // Both reducers are stable constants — no closure state. Bounds live in
   // each item's TransformPrivateState and are updated via "set-bounds".
@@ -316,7 +405,10 @@ function createCarouselReduce(config: CarouselConfig) {
       }
     }
 
-    if (state.type === "items" && !newItemIds.includes(state.activeItemId)) {
+    if (
+      (state.type === "items" || state.type === "dismissing") &&
+      !newItemIds.includes(state.activeItemId)
+    ) {
       return {
         type: "free",
         itemWidth: newItemWidth,
@@ -428,8 +520,33 @@ function createCarouselReduce(config: CarouselConfig) {
           }
           case "release":
             return state;
-          case "slop":
+          case "slop": {
+            if (
+              dismissible &&
+              state.carousel.type === "settled" &&
+              action.itemId !== undefined &&
+              Math.abs(action.dy) > Math.abs(action.dx)
+            ) {
+              const item = state.items[action.itemId];
+              if (item?.transform.scale === 1 && item.type === "settled") {
+                return {
+                  type: "dismissing",
+                  itemWidth: state.itemWidth,
+                  itemHeight: state.itemHeight,
+                  itemIds: state.itemIds,
+                  carousel: state.carousel,
+                  items: state.items,
+                  activeItemId: action.itemId,
+                  dismissX: 0,
+                  dismissY: 0,
+                  dismissVx: 0,
+                  dismissVy: 0,
+                  lastUpdatedAt: action.timestamp,
+                };
+              }
+            }
             return state;
+          }
           case "toggle-zoom": {
             if (action.itemId === undefined) return state;
             const item = state.items[action.itemId];
@@ -572,6 +689,84 @@ function createCarouselReduce(config: CarouselConfig) {
           }
         }
         throw new Error("unreachable");
+      }
+
+      case "dismissing": {
+        switch (action.type) {
+          case "motion": {
+            if (action.itemId !== state.activeItemId) return state;
+            const dtMs = computeDtMs(state.lastUpdatedAt, action.timestamp);
+            const dismissX = state.dismissX + action.dx;
+            const dismissY = state.dismissY + action.dy;
+            return {
+              ...state,
+              dismissX,
+              dismissY,
+              dismissVx: dtMs > 0 ? action.dx / dtMs : state.dismissVx,
+              dismissVy: dtMs > 0 ? action.dy / dtMs : state.dismissVy,
+              lastUpdatedAt: action.timestamp,
+            };
+          }
+          case "release": {
+            const projectedY = state.dismissY + state.dismissVy / INERTIA_DECAY;
+            if (Math.abs(projectedY) > state.itemHeight * 0.5) {
+              return {
+                type: "dismissed",
+                itemWidth: state.itemWidth,
+                itemHeight: state.itemHeight,
+                itemIds: state.itemIds,
+                carousel: state.carousel,
+                items: state.items,
+              };
+            }
+            const activeItem = state.items[state.activeItemId];
+            return {
+              type: "free",
+              itemWidth: state.itemWidth,
+              itemHeight: state.itemHeight,
+              itemIds: state.itemIds,
+              carousel: state.carousel,
+              items: {
+                ...state.items,
+                [state.activeItemId]: {
+                  type: "snapping" as const,
+                  bounds: activeItem?.bounds ?? {
+                    elementWidth: state.itemWidth,
+                    elementHeight: state.itemHeight,
+                    left: 0,
+                    right: state.itemWidth,
+                    top: 0,
+                    bottom: state.itemHeight,
+                  },
+                  transform: {
+                    x: state.dismissX,
+                    y: state.dismissY,
+                    scale: deriveDismissScale(state.dismissY, state.itemHeight),
+                  },
+                  lastUpdatedAt: state.lastUpdatedAt,
+                  target: { x: 0, y: 0, scale: 1 },
+                },
+              },
+            };
+          }
+          case "slop":
+          case "toggle-zoom":
+            return state;
+          case "tick": {
+            const carousel = carouselReduce(state.carousel, action);
+            const items = advanceAllItems(state.items, action.timestamp);
+            if (carousel === state.carousel && items === state.items)
+              return state;
+            return { ...state, carousel, items };
+          }
+        }
+        throw new Error("unreachable");
+      }
+
+      case "dismissed": {
+        // Returning the same reference satisfies the reference-equality contract,
+        // keeping the animation loop paused until the component unmounts.
+        return state;
       }
     }
   };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -24,6 +24,9 @@ export type InterpreterEvent =
       dScale: number;
       originX: number;
       originY: number;
+      /** Initial touch/pointer position relative to the element's top-left corner (px). */
+      pointerX: number;
+      pointerY: number;
       timestamp: number;
     }
   | {

--- a/packages/demo/src/ScalableCarouselDemo.tsx
+++ b/packages/demo/src/ScalableCarouselDemo.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import { useRef, useState } from "react";
 import { flushSync } from "react-dom";
 import {
@@ -40,6 +41,8 @@ export function ScalableCarouselDemo() {
     const { id } = items[index];
     const gridImg = gridImgRefs.current.get(id);
     const carouselImg = carouselImgRefs.current.get(id);
+
+    dialogRef.current?.style.setProperty("--dismiss-progress", "0");
 
     if (!document.startViewTransition) {
       setSelectedItemId(id);
@@ -133,6 +136,9 @@ export function ScalableCarouselDemo() {
 
             object-fit: cover;
           }
+          dialog::backdrop {
+            background: rgba(0, 0, 0, calc(0.6 * (1 - var(--dismiss-progress, 0))));
+          }
           `}
       </style>
       <div className="grid grid-cols-3 gap-2">
@@ -160,7 +166,12 @@ export function ScalableCarouselDemo() {
       {/* biome-ignore lint/a11y/useKeyWithClickEvents: <dialog> natively closes on Escape */}
       <dialog
         ref={dialogRef}
-        className="bg-gray-900 p-0 max-w-none max-h-none w-screen h-screen backdrop:bg-black/60"
+        className="bg-gray-900 p-0 max-w-none max-h-none w-screen h-screen"
+        style={
+          {
+            "--dismiss-progress": "0",
+          } as React.CSSProperties
+        }
         onClick={handleBackdropClick}
       >
         <div className="flex flex-col h-full">
@@ -180,6 +191,13 @@ export function ScalableCarouselDemo() {
               itemHeight={ITEM_HEIGHT}
               selectedItemId={selectedItemId}
               onSelectedItemIdChange={setSelectedItemId}
+              onDismiss={closeModal}
+              onDismissProgress={(progress) => {
+                dialogRef.current?.style.setProperty(
+                  "--dismiss-progress",
+                  String(progress),
+                );
+              }}
             >
               {items.map(({ id, photoId }) => (
                 <ScalableCarouselItem

--- a/packages/react/src/ScalableCarouselContainer.tsx
+++ b/packages/react/src/ScalableCarouselContainer.tsx
@@ -207,6 +207,17 @@ export function ScalableCarouselContainer({
       }
       if (state.isDismissed && !prevState.isDismissed) {
         onDismissRef.current?.();
+        // Reset to free so the carousel is usable when the dialog re-opens.
+        // Without this, if selectedItemId doesn't change, useLayoutEffect won't
+        // re-dispatch navigate-to and the carousel stays stuck in dismissed.
+        const index = Math.round(
+          -state.carouselTranslateX / itemWidthRef.current,
+        );
+        const clamped = Math.max(
+          0,
+          Math.min(itemIdsRef.current.length - 1, index),
+        );
+        s.dispatch({ type: "navigate-to", index: clamped });
       }
       if (state.dismissProgress !== prevState.dismissProgress) {
         onDismissProgressRef.current?.(state.dismissProgress);

--- a/packages/react/src/ScalableCarouselContainer.tsx
+++ b/packages/react/src/ScalableCarouselContainer.tsx
@@ -105,7 +105,6 @@ export function ScalableCarouselItem({
         width: ctx?.itemWidth ?? 0,
         height: ctx?.itemHeight ?? 0,
         flexShrink: 0,
-        overflow: "hidden",
         cursor: "grab",
       }}
     >
@@ -260,7 +259,7 @@ export function ScalableCarouselContainer({
   return (
     <div
       className={className}
-      style={{ overflow: "hidden", touchAction: "none" }}
+      style={{ touchAction: "none" }}
     >
       <div ref={stripRef} style={{ display: "flex" }}>
         <CarouselContext.Provider value={contextValue}>

--- a/packages/react/src/ScalableCarouselContainer.tsx
+++ b/packages/react/src/ScalableCarouselContainer.tsx
@@ -126,6 +126,8 @@ type Props = {
   itemHeight: number;
   selectedItemId?: string;
   onSelectedItemIdChange?: (itemId: string) => void;
+  onDismiss?: () => void;
+  onDismissProgress?: (progress: number) => void;
   className?: string;
 };
 
@@ -145,6 +147,8 @@ export function ScalableCarouselContainer({
   itemHeight,
   selectedItemId,
   onSelectedItemIdChange,
+  onDismiss,
+  onDismissProgress,
   className,
 }: Props) {
   const stripRef = useRef<HTMLDivElement>(null);
@@ -166,6 +170,12 @@ export function ScalableCarouselContainer({
   const onSelectedItemIdChangeRef = useRef(onSelectedItemIdChange);
   onSelectedItemIdChangeRef.current = onSelectedItemIdChange;
 
+  const onDismissRef = useRef(onDismiss);
+  onDismissRef.current = onDismiss;
+
+  const onDismissProgressRef = useRef(onDismissProgress);
+  onDismissProgressRef.current = onDismissProgress;
+
   const itemIdsKey = itemIds.join(",");
 
   useEffect(() => {
@@ -174,6 +184,7 @@ export function ScalableCarouselContainer({
         itemWidth: itemWidthRef.current,
         itemHeight: itemHeightRef.current,
         itemIds: itemIdsRef.current,
+        dismissible: !!onDismissRef.current,
       }),
     );
 
@@ -194,6 +205,12 @@ export function ScalableCarouselContainer({
         const id = itemIdsRef.current[clamped];
         if (id !== undefined) onSelectedItemIdChangeRef.current?.(id);
       }
+      if (state.isDismissed && !prevState.isDismissed) {
+        onDismissRef.current?.();
+      }
+      if (state.dismissProgress !== prevState.dismissProgress) {
+        onDismissProgressRef.current?.(state.dismissProgress);
+      }
     });
 
     return () => {
@@ -211,6 +228,7 @@ export function ScalableCarouselContainer({
         itemWidth: itemWidthRef.current,
         itemHeight: itemHeightRef.current,
         itemIds: itemIdsRef.current,
+        dismissible: !!onDismissRef.current,
       },
     });
   }, [store, itemWidth, itemHeight, itemIdsKey]);


### PR DESCRIPTION
CLAUDE: Closes #33

## Summary

- Adds `dismissing` and `dismissed` states to the carousel model, gated behind a `dismissible?: boolean` config flag
- Tracks dismiss gesture in flat fields (`dismissX/Y`, `dismissVx/Vy`) rather than reusing `TransformPrivateState`, since dismiss motion has no bounds, no pinch scale, and scale is derived from `|y|` rather than tracked
- Exposes `isDismissed` / `dismissProgress` in `CarouselPublicState` as a discriminated union so `isDismissed: true` implies `dismissProgress: 1` at the type level
- Adds `onDismiss` and `onDismissProgress` props to `ScalableCarouselContainer`
- `ScalableCarouselDemo` fades the backdrop via a CSS custom property driven by `onDismissProgress`, and calls `closeModal()` via `onDismiss`
- Follow-up fixes: carousel responsiveness after dismiss+re-open, view transition origin, scale transform origin at pointer, clipping during dismiss animation

## Test plan

- [ ] Swipe an item upward/downward past threshold → modal closes with view transition
- [ ] Swipe slowly and release before threshold → item springs back to center
- [ ] Backdrop fades during swipe and returns on snap-back
- [ ] Pinch-zoom an item, then swipe up → dismiss does NOT trigger (item is zoomed)
- [ ] Swipe horizontally → scrolls carousel, not dismiss
- [ ] Swipe diagonally (more horizontal than vertical) → carousel scrolls, not dismiss
- [ ] `npm run tsc && npm run format && npm run lint && npm run test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)