### PR TITLE
Carousel: navigate-by action, navigateBy handle, onScaleChange, style prop

### DIFF
--- a/design/00_architecture.md
+++ b/design/00_architecture.md
@@ -208,7 +208,7 @@ Dispatching `set-config` updates the item list while preserving carousel animati
 
 Dispatching `navigate-to` immediately moves the carousel strip to the given item index (clamped to the valid range), cancelling any in-progress gesture or animation. The model transitions to the `free` state.
 
-Dispatching `navigate-by` starts a smooth snap to the item `delta` positions away (negative = backward), clamped to the valid range. It is only meaningful while the strip is at rest or snapping and is ignored mid-gesture. While a snap is already in progress, the step is taken relative to the snap destination so repeated dispatches accumulate. This backs prev/next buttons and arrow-key navigation in hosting applications.
+Dispatching `navigate-by` starts a smooth snap to the item `delta` positions away (negative = backward), clamped to the valid range. It is only meaningful while the strip is at rest or snapping and is ignored mid-gesture. While a snap is already in progress, the step is taken relative to the snap destination so repeated dispatches accumulate.
 
 The public state includes a discriminated dismiss union:
 

--- a/design/00_architecture.md
+++ b/design/00_architecture.md
@@ -200,12 +200,15 @@ type CarouselConfig = {
 type CarouselAction =
   | TransformAction
   | { type: "set-config"; config: CarouselConfig }
-  | { type: "navigate-to"; index: number };
+  | { type: "navigate-to"; index: number }
+  | { type: "navigate-by"; delta: number };
 ```
 
 Dispatching `set-config` updates the item list while preserving carousel animation state. The carousel strip stays anchored to the item the gesture was heading toward; deleted items lose their transform state; new items start at the neutral transform. If the active item (currently being panned/zoomed) is deleted, the model transitions immediately to the `free` state.
 
 Dispatching `navigate-to` immediately moves the carousel strip to the given item index (clamped to the valid range), cancelling any in-progress gesture or animation. The model transitions to the `free` state.
+
+Dispatching `navigate-by` starts a smooth snap to the item `delta` positions away (negative = backward), clamped to the valid range. It is only meaningful while the strip is at rest or snapping and is ignored mid-gesture. While a snap is already in progress, the step is taken relative to the snap destination so repeated dispatches accumulate. This backs prev/next buttons and arrow-key navigation in hosting applications.
 
 The public state includes a discriminated dismiss union:
 

--- a/packages/core/src/model/__tests__/carousel.test.ts
+++ b/packages/core/src/model/__tests__/carousel.test.ts
@@ -1158,6 +1158,72 @@ describe("createCarouselModel", () => {
   });
 
   // -------------------------------------------------------------------------
+  // navigate-by
+  // -------------------------------------------------------------------------
+
+  describe("navigate-by", () => {
+    it("starts a smooth snap to the next item", () => {
+      const reduce = makeReduce();
+      const next = reduce(free(), { type: "navigate-by", delta: 1 });
+      expect(next.type).toBe("free");
+      expect(next.carousel.type).toBe("snapping");
+      if (next.carousel.type === "snapping") {
+        expect(next.carousel.target.x).toBe(-ITEM_WIDTH);
+      }
+    });
+
+    it("converges and settles at the target", () => {
+      const { reduce, publish } = createCarouselModel(DEFAULT_CONFIG);
+      let state = reduce(free(), { type: "navigate-by", delta: 1 });
+      for (let t = 16; t < 2000; t += 16) {
+        state = reduce(state, { type: "tick", timestamp: t });
+      }
+      const pub = publish(state);
+      expect(pub.isCarouselSettled).toBe(true);
+      expect(pub.carouselTranslateX).toBe(-ITEM_WIDTH);
+    });
+
+    it("clamps at the last item", () => {
+      const reduce = makeReduce();
+      const state = free(-(ITEM_IDS.length - 1) * ITEM_WIDTH);
+      // Reference equality: no-op keeps the animation loop paused.
+      expect(reduce(state, { type: "navigate-by", delta: 1 })).toBe(state);
+    });
+
+    it("clamps at the first item", () => {
+      const reduce = makeReduce();
+      const state = free();
+      expect(reduce(state, { type: "navigate-by", delta: -1 })).toBe(state);
+    });
+
+    it("accumulates from the snap target while snapping", () => {
+      const reduce = makeReduce();
+      let state = reduce(free(), { type: "navigate-by", delta: 1 });
+      state = reduce(state, { type: "tick", timestamp: 16 }); // mid-animation
+      state = reduce(state, { type: "navigate-by", delta: 1 });
+      expect(state.carousel.type).toBe("snapping");
+      if (state.carousel.type === "snapping") {
+        expect(state.carousel.target.x).toBe(-2 * ITEM_WIDTH);
+      }
+    });
+
+    it("is ignored during an item gesture", () => {
+      const reduce = makeReduce();
+      const state = makeItemsState();
+      expect(reduce(state, { type: "navigate-by", delta: 1 })).toBe(state);
+    });
+
+    it("is a no-op with empty itemIds", () => {
+      const { reduce } = createCarouselModel({
+        ...DEFAULT_CONFIG,
+        itemIds: [],
+      });
+      const state = reduce(undefined, { type: "tick", timestamp: 0 });
+      expect(reduce(state, { type: "navigate-by", delta: 1 })).toBe(state);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // publish
   // -------------------------------------------------------------------------
 

--- a/packages/core/src/model/carousel.ts
+++ b/packages/core/src/model/carousel.ts
@@ -41,7 +41,8 @@ export type CarouselPublicState = {
 export type CarouselAction =
   | Exclude<TransformAction, { type: "set-bounds" }>
   | { type: "set-config"; config: CarouselConfig }
-  | { type: "navigate-to"; index: number };
+  | { type: "navigate-to"; index: number }
+  | { type: "navigate-by"; delta: number };
 
 // ---------------------------------------------------------------------------
 // Internal types
@@ -498,6 +499,36 @@ function createCarouselReduce(config: CarouselConfig) {
           lastUpdatedAt: Number.NaN,
         },
         items: state.items,
+      };
+    }
+
+    if (action.type === "navigate-by") {
+      // Only meaningful while the strip is at rest or snapping; ignored mid-gesture.
+      if (state.type !== "free" || state.itemIds.length === 0) return state;
+      const { carousel } = state;
+      // While snapping, step relative to the destination so repeated presses accumulate.
+      const baseX =
+        carousel.type === "snapping" ? carousel.target.x : carousel.transform.x;
+      const baseIndex = Math.round(-baseX / state.itemWidth);
+      const clampedIndex = Math.max(
+        0,
+        Math.min(state.itemIds.length - 1, baseIndex + action.delta),
+      );
+      const targetX = -clampedIndex * state.itemWidth;
+      if (
+        carousel.type === "snapping"
+          ? carousel.target.x === targetX
+          : carousel.transform.x === targetX
+      )
+        return state;
+      return {
+        ...state,
+        carousel: {
+          type: "snapping",
+          transform: carousel.transform,
+          lastUpdatedAt: carousel.lastUpdatedAt,
+          target: { x: targetX, y: 0, scale: 1 },
+        },
       };
     }
 

--- a/packages/core/src/model/carousel.ts
+++ b/packages/core/src/model/carousel.ts
@@ -503,24 +503,18 @@ function createCarouselReduce(config: CarouselConfig) {
     }
 
     if (action.type === "navigate-by") {
-      // Only meaningful while the strip is at rest or snapping; ignored mid-gesture.
       if (state.type !== "free" || state.itemIds.length === 0) return state;
       const { carousel } = state;
       // While snapping, step relative to the destination so repeated presses accumulate.
       const baseX =
         carousel.type === "snapping" ? carousel.target.x : carousel.transform.x;
-      const baseIndex = Math.round(-baseX / state.itemWidth);
-      const clampedIndex = Math.max(
+      const targetX = computeCarouselSnapTarget(
+        baseX - action.delta * state.itemWidth,
         0,
-        Math.min(state.itemIds.length - 1, baseIndex + action.delta),
+        state.itemWidth,
+        state.itemIds.length,
       );
-      const targetX = -clampedIndex * state.itemWidth;
-      if (
-        carousel.type === "snapping"
-          ? carousel.target.x === targetX
-          : carousel.transform.x === targetX
-      )
-        return state;
+      if (baseX === targetX) return state;
       return {
         ...state,
         carousel: {

--- a/packages/core/src/model/transform.ts
+++ b/packages/core/src/model/transform.ts
@@ -284,7 +284,6 @@ export function createTransformReduce(config?: TransformConfig) {
               if (newScale < minScale) {
                 newScale = minScale;
                 newLogVScale = 0;
-                0;
               }
             }
             const ds = newScale / state.transform.scale;

--- a/packages/core/src/model/transform.ts
+++ b/packages/core/src/model/transform.ts
@@ -81,7 +81,7 @@ function computeMinScale(bounds: BoundsConfig): number {
   return minScale;
 }
 
-const SNAP_DECAY = 0.80; // per-frame interpolation factor toward snap target
+const SNAP_DECAY = 0.8; // per-frame interpolation factor toward snap target
 const SNAP_THRESHOLD = 0.5; // px
 const SCALE_SNAP_THRESHOLD = 0.001;
 const VELOCITY_THRESHOLD = 0.01; // px/ms
@@ -284,7 +284,8 @@ export function createTransformReduce(config?: TransformConfig) {
               if (newScale < minScale) {
                 newScale = minScale;
                 newLogVScale = 0;
-0            }
+                0;
+              }
             }
             const ds = newScale / state.transform.scale;
 

--- a/packages/demo/src/ScalableCarouselDemo.tsx
+++ b/packages/demo/src/ScalableCarouselDemo.tsx
@@ -9,8 +9,8 @@ import {
 } from "@mimosa/core";
 import { ScalableCarouselContainer, ScalableCarouselItem } from "@mimosa/react";
 
-const ITEM_WIDTH = '100%';
-const ITEM_HEIGHT = '100%';
+const ITEM_WIDTH = "100%";
+const ITEM_HEIGHT = "100%";
 const ITEM_SOURCE_WIDTH = 300;
 const ITEM_SOURCE_HEIGHT = 400;
 

--- a/packages/react/src/ScalableCarouselContainer.tsx
+++ b/packages/react/src/ScalableCarouselContainer.tsx
@@ -71,17 +71,24 @@ type ScalableCarouselItemProps = {
   children?: ReactNode;
   // Frozen at mount. To swap interpreters, remount via a key change.
   interpreters: Interpreter[];
+  /** Notifies raw scale value whenever this item's published scale changes.
+      Fires potentially every frame during pinch/animation; handler must be cheap.
+      (During dismiss gesture, values < 1 also flow through.) */
+  onScaleChange?: (scale: number) => void;
 };
 
 export function ScalableCarouselItem({
   id,
   children,
   interpreters,
+  onScaleChange,
 }: ScalableCarouselItemProps) {
   const ctx = useContext(CarouselContext);
   const viewportRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const interpretersRef = useRef(interpreters);
+  const onScaleChangeRef = useRef(onScaleChange);
+  onScaleChangeRef.current = onScaleChange;
 
   useEffect(() => {
     if (!ctx) return;
@@ -102,12 +109,15 @@ export function ScalableCarouselItem({
 
   useEffect(() => {
     if (!ctx) return;
-    return ctx.store.subscribe((state) => {
+    return ctx.store.subscribe((state, prevState) => {
       const el = contentRef.current;
       const itemState = state.items[id];
       if (el && itemState) {
         el.style.transform = `translate(${itemState.transformX}px, ${itemState.transformY}px) scale(${itemState.scale})`;
         el.style.transformOrigin = "0 0";
+      }
+      if (itemState && itemState.scale !== prevState.items[id]?.scale) {
+        onScaleChangeRef.current?.(itemState.scale);
       }
     });
   }, [ctx, id]);

--- a/packages/react/src/ScalableCarouselContainer.tsx
+++ b/packages/react/src/ScalableCarouselContainer.tsx
@@ -152,6 +152,7 @@ type Props = {
   onDismiss?: () => void;
   onDismissProgress?: (progress: number) => void;
   className?: string;
+  style?: React.CSSProperties;
 };
 
 export type ScalableCarouselContainerHandle = {
@@ -185,6 +186,7 @@ export const ScalableCarouselContainer = forwardRef<
     onDismiss,
     onDismissProgress,
     className,
+    style,
   },
   ref,
 ) {
@@ -382,7 +384,7 @@ export const ScalableCarouselContainer = forwardRef<
     <div
       ref={containerRef}
       className={className}
-      style={{ touchAction: "none" }}
+      style={{ touchAction: "none", ...style }}
     >
       <div ref={stripRef} style={{ display: "flex" }}>
         <CarouselContext.Provider value={contextValue}>

--- a/packages/react/src/ScalableCarouselContainer.tsx
+++ b/packages/react/src/ScalableCarouselContainer.tsx
@@ -10,6 +10,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
   type ReactNode,
 } from "react";
 import {
@@ -152,7 +153,7 @@ type Props = {
   onDismiss?: () => void;
   onDismissProgress?: (progress: number) => void;
   className?: string;
-  style?: React.CSSProperties;
+  style?: CSSProperties;
 };
 
 export type ScalableCarouselContainerHandle = {

--- a/packages/react/src/ScalableCarouselContainer.tsx
+++ b/packages/react/src/ScalableCarouselContainer.tsx
@@ -1,9 +1,11 @@
 import {
   Children,
   createContext,
+  forwardRef,
   isValidElement,
   useContext,
   useEffect,
+  useImperativeHandle,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -142,6 +144,14 @@ type Props = {
   className?: string;
 };
 
+export type ScalableCarouselContainerHandle = {
+  /**
+   * Animates the carousel to the item `delta` positions away (negative =
+   * backward), clamped to the ends. No-op during an active gesture.
+   */
+  navigateBy: (delta: number) => void;
+};
+
 function deriveItemIds(children: ReactNode): readonly string[] {
   return Children.toArray(children)
     .filter(
@@ -152,16 +162,22 @@ function deriveItemIds(children: ReactNode): readonly string[] {
     .map((child) => child.props.id);
 }
 
-export function ScalableCarouselContainer({
-  children,
-  itemWidth,
-  itemHeight,
-  selectedItemId,
-  onSelectedItemIdChange,
-  onDismiss,
-  onDismissProgress,
-  className,
-}: Props) {
+export const ScalableCarouselContainer = forwardRef<
+  ScalableCarouselContainerHandle,
+  Props
+>(function ScalableCarouselContainer(
+  {
+    children,
+    itemWidth,
+    itemHeight,
+    selectedItemId,
+    onSelectedItemIdChange,
+    onDismiss,
+    onDismissProgress,
+    className,
+  },
+  ref,
+) {
   const stripRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const containerPxRef = useRef<{ width: number; height: number } | null>(null);
@@ -340,6 +356,16 @@ export function ScalableCarouselContainer({
     store.flush();
   }, [store, selectedItemId]);
 
+  useImperativeHandle(
+    ref,
+    () => ({
+      navigateBy: (delta: number) => {
+        storeRef.current?.dispatch({ type: "navigate-by", delta });
+      },
+    }),
+    [],
+  );
+
   const contextValue = useMemo(() => (store ? { store } : null), [store]);
 
   return (
@@ -355,4 +381,4 @@ export function ScalableCarouselContainer({
       </div>
     </div>
   );
-}
+});

--- a/packages/react/src/ScalableCarouselContainer.tsx
+++ b/packages/react/src/ScalableCarouselContainer.tsx
@@ -72,9 +72,11 @@ type ScalableCarouselItemProps = {
   children?: ReactNode;
   // Frozen at mount. To swap interpreters, remount via a key change.
   interpreters: Interpreter[];
-  /** Notifies raw scale value whenever this item's published scale changes.
-      Fires potentially every frame during pinch/animation; handler must be cheap.
-      (During dismiss gesture, values < 1 also flow through.) */
+  /**
+   * Notifies raw scale value whenever this item's published scale changes.
+   * Fires potentially every frame during pinch/animation; handler must be
+   * cheap. (During dismiss gesture, values < 1 also flow through.)
+   */
   onScaleChange?: (scale: number) => void;
 };
 
@@ -385,7 +387,7 @@ export const ScalableCarouselContainer = forwardRef<
     <div
       ref={containerRef}
       className={className}
-      style={{ touchAction: "none", ...style }}
+      style={{ ...style, touchAction: "none" }}
     >
       <div ref={stripRef} style={{ display: "flex" }}>
         <CarouselContext.Provider value={contextValue}>

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,5 +1,6 @@
 export { PinchPanContainer } from "./PinchPanContainer.js";
 export {
   ScalableCarouselContainer,
+  type ScalableCarouselContainerHandle,
   ScalableCarouselItem,
 } from "./ScalableCarouselContainer.js";


### PR DESCRIPTION
CLAUDE:

## Summary

### 1. `navigate-by` carousel action + `navigateBy` imperative handle

- New `{ type: "navigate-by"; delta: number }` action on the carousel model: relative navigation clamped to the ends, ignored mid-gesture. While a snap is already in progress it steps relative to the snap destination, so repeated dispatches accumulate. Reuses `computeCarouselSnapTarget` for the round/clamp math, which also rounds fractional deltas to the nearest snap point.
- `ScalableCarouselContainer` is now a `forwardRef` component exposing `ScalableCarouselContainerHandle` with `navigateBy(delta)`. Downstream this backs prev/next chevron buttons and arrow-key navigation.
- Covered by 7 new unit tests, including reference-equality no-op checks so the store's pause optimization is preserved.
- `design/00_architecture.md` documents the new action.

### 2. `onScaleChange` callback on `ScalableCarouselItem`

Notifies the raw published scale whenever it changes, piggybacking on the existing store subscription (no new subscription; callback routed through a ref so identity changes don't remount the effect). Downstream use case: upgrading a photo to its original-quality source once the user zooms in.

Known trade-off surfaced by review: the published per-item scale is a composite (dismiss shrink also flows through, documented on the prop). Exposing the pinch-zoom scale as its own field in the publish projection would be the cleaner long-term fix — left out of this port to keep parity with the downstream-verified behavior.

### 3. `style` prop on `ScalableCarouselContainer`

Merged under the built-in `touchAction: "none"` so callers can size/position the container without a wrapper (the downstream modal relies on this).

Also includes a drive-by removal of a stray `0;` expression statement in `transform.ts` left over from an earlier edit.

## Possible follow-ups (not in this PR)

- Unify `navigate-to`/`navigate-by` into a single `{ type: "navigate"; index; behavior: "instant" | "smooth" }` primitive covering absolute/relative × instant/smooth.
- Wire the demo's prev/next buttons to `navigateBy` to dogfood the handle.

## Test plan

- `npm run tsc && npm run format && npm run lint && npm run test`: all green, 158 tests passed (7 new).
- The identical logic (modulo the review polish in the last commit) is already exercised in production downstream via speciesbox-web#300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)