### PR TITLE
Switch npm publishing to OIDC trusted publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
-          registry-url: https://registry.npmjs.org
       - run: npm ci
       - run: npm run build
       - run: npm config set provenance true
@@ -27,5 +26,3 @@ jobs:
           publish: npx changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,9 +38,9 @@ This project uses [Changesets](https://github.com/changesets/changesets) to mana
 
 2. **Version PR** — When changesets are merged to `main`, the GitHub Actions release workflow (`release.yml`) runs `changesets/action`, which opens (or updates) a "Version Packages" pull request. This PR bumps `package.json` versions and updates `CHANGELOG.md` files based on the accumulated changesets.
 
-3. **Publish** — Merging the Version PR back to `main` triggers the workflow again. This time `changesets/action` detects that the versions have already been bumped, so it runs `npx changeset publish --provenance` to publish the packages to npm with provenance attestation.
+3. **Publish** — Merging the Version PR back to `main` triggers the workflow again. This time `changesets/action` detects that the versions have already been bumped, so it runs `npx changeset publish` to publish the packages to npm. Provenance attestation is enabled via `npm config set provenance true` in the workflow.
 
-Required repository secrets: `NPM_TOKEN` (an npm automation token with publish access).
+Publishing uses [npm trusted publishers](https://docs.npmjs.com/trusted-publishers) (OIDC) — no long-lived `NPM_TOKEN` is needed. Each package must have the trusted publisher configured on npmjs.com (Settings → Trusted Publisher → GitHub Actions, workflow: `release.yml`).
 
 ## Human Language
 


### PR DESCRIPTION
CLAUDE:

## Summary

- Removes `NPM_TOKEN` / `NODE_AUTH_TOKEN` from the release workflow in favour of [npm trusted publishers](https://docs.npmjs.com/trusted-publishers) (OIDC)
- Removes `registry-url` from `actions/setup-node` — it was only needed to write the `NODE_AUTH_TOKEN`-based `.npmrc`
- Bumps Node.js from 20 → 22 (OIDC requires Node 22.14.0+)
- Updates `CLAUDE.md` to document the new publishing approach

## Before merging

- [ ] On npmjs.com, go to each package's Settings → Trusted Publisher and configure:
  - **Organization / user:** `ykiu`
  - **Repository:** `thigma`
  - **Workflow filename:** `release.yml`
  - **Allowed actions:** `npm publish`

  Do this for both `@thigma/core` and `@thigma/react`.

- [ ] Remove the `NPM_TOKEN` secret from the repo settings (optional but recommended once the above is verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)